### PR TITLE
link: Add missing link translation

### DIFF
--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -46,9 +46,12 @@
     "posts": "Nouveautés",
     "show-your-interest": "Faites part de votre intérêt",
     "sponsors": "Sponsors",
+    "partners": "Partenaires",
+    "status": "Status des services",
     "donate": "Don",
     "store": "Boutique",
-    "press": "Presse"
+    "press": "Presse",
+    "download": "Télécharger"
   },
   "socials": {
     "forums": "Forums",


### PR DESCRIPTION
Linked to issue #97 
When you go the the Rocky website, some string was missing and appear as links.*