### PR TITLE
Add new strings for translation

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "author": "Rocky Linux Web Team <www@rockylinux.org> (https://rockylinux.org)",
   "dependencies": {
     "@headlessui/react": "^0.2.0",
-    "gatsby": "^2.32.3",
+    "dompurify": "^2.2.8",
+    "gatsby": "^3.4.2",
     "gatsby-image": "^2.4.20",
     "gatsby-plugin-feed": "^2.13.0",
     "gatsby-plugin-manifest": "^2.4.33",

--- a/src/components/footer/index.jsx
+++ b/src/components/footer/index.jsx
@@ -20,7 +20,7 @@ const Footer = ({ pageContext: { locale: language } }) => {
               href="https://wiki.rockylinux.org/contributing"
               className="text-base text-gray-600 dark:text-gray-400 hover:text-gray-500 dark:hover:text-white"
             >
-              {translate('links.get-involved')}
+              {translate('global.links.get-involved')}
             </a>
           </div>
           <div className="px-5 py-2">
@@ -28,7 +28,7 @@ const Footer = ({ pageContext: { locale: language } }) => {
               to="/sponsors/"
               className="text-base text-gray-600 dark:text-gray-400 hover:text-gray-500 dark:hover:text-white"
             >
-              {translate('links.sponsors')}
+              {translate('global.links.sponsors')}
             </LocalizedLink>
           </div>
           <div className="px-5 py-2">
@@ -36,7 +36,7 @@ const Footer = ({ pageContext: { locale: language } }) => {
               href="https://status.rockylinux.org/"
               className="text-base text-gray-600 dark:text-gray-400 hover:text-gray-500 dark:hover:text-white"
             >
-              {translate('links.status')}
+              {translate('global.links.status')}
             </a>
           </div>
           <div className="px-5 py-2">
@@ -44,7 +44,7 @@ const Footer = ({ pageContext: { locale: language } }) => {
               to="/partners/"
               className="text-base text-gray-600 dark:text-gray-400 hover:text-gray-500 dark:hover:text-white"
             >
-              {translate('links.partners')}
+              {translate('global.links.partners')}
             </LocalizedLink>
           </div>
           <div className="px-5 py-2">
@@ -52,7 +52,7 @@ const Footer = ({ pageContext: { locale: language } }) => {
               to="/press/1/"
               className="text-base text-gray-600 dark:text-gray-400 hover:text-gray-500 dark:hover:text-white"
             >
-              {translate('links.press')}
+              {translate('global.links.press')}
             </LocalizedLink>
           </div>
         </nav>
@@ -61,7 +61,7 @@ const Footer = ({ pageContext: { locale: language } }) => {
             href="https://twitter.com/rocky_linux"
             className="text-gray-600 dark:text-gray-400 hover:text-gray-500 dark:hover:text-white"
           >
-            <span className="sr-only">{translate('socials.twitter')}</span>
+            <span className="sr-only">{translate('global.socials.twitter')}</span>
             <svg
               className="h-6 w-6"
               fill="currentColor"
@@ -75,7 +75,7 @@ const Footer = ({ pageContext: { locale: language } }) => {
             href="https://reddit.com/r/rockylinux"
             className="text-gray-600 dark:text-gray-400 hover:text-gray-500 dark:hover:text-white"
           >
-            <span className="sr-only">{translate('socials.reddit')}</span>
+            <span className="sr-only">{translate('global.socials.reddit')}</span>
             <svg
               className="h-6 w-6"
               fill="currentColor"
@@ -89,7 +89,7 @@ const Footer = ({ pageContext: { locale: language } }) => {
             href="https://forums.rockylinux.org/"
             className="text-gray-600 dark:text-gray-400 hover:text-gray-500 dark:hover:text-white"
           >
-            <span className="sr-only">{translate('socials.forums')}</span>
+            <span className="sr-only">{translate('global.socials.forums')}</span>
             <svg
               className="h-6 w-6"
               fill="currentColor"
@@ -104,7 +104,7 @@ const Footer = ({ pageContext: { locale: language } }) => {
             href="https://chat.rockylinux.org/"
             className="text-gray-600 dark:text-gray-400 hover:text-gray-500 dark:hover:text-white"
           >
-            <span className="sr-only">{translate('socials.mattermost')}</span>
+            <span className="sr-only">{translate('global.socials.mattermost')}</span>
             <svg
               className="h-6 w-6"
               fill="currentColor"
@@ -118,7 +118,7 @@ const Footer = ({ pageContext: { locale: language } }) => {
             href="https://github.com/rocky-linux"
             className="text-gray-600 dark:text-gray-400 hover:text-gray-500 dark:hover:text-white"
           >
-            <span className="sr-only">{translate('socials.github')}</span>
+            <span className="sr-only">{translate('global.socials.github')}</span>
             <svg
               className="h-6 w-6"
               fill="currentColor"
@@ -224,7 +224,7 @@ const Footer = ({ pageContext: { locale: language } }) => {
               to="/community-charter/"
               className="text-sm text-gray-500 hover:text-gray-400"
             >
-              {translate('links.com_charter')}
+              {translate('global.links.com_charter')}
             </LocalizedLink>
           </div>
           <div className="px-5 py-2">
@@ -232,7 +232,7 @@ const Footer = ({ pageContext: { locale: language } }) => {
               to="/organizational-structure/"
               className="text-sm text-gray-500 hover:text-gray-400"
             >
-              {translate('links.org_structure')}
+              {translate('global.links.org_structure')}
             </LocalizedLink>
           </div>
           <div className="px-5 py-2">
@@ -240,15 +240,15 @@ const Footer = ({ pageContext: { locale: language } }) => {
               to="/privacy-policy/"
               className="text-sm text-gray-500 hover:text-gray-400"
             >
-              {translate('links.privacy')}
+              {translate('global.links.privacy')}
             </LocalizedLink>
           </div>
         </nav>
         <p className="text-center text-base text-gray-500" dir="auto">
-          {translate('copyright.line1')}
+          {translate('global.copyright.line1')}
         </p>
         <p className="mt-2 text-center text-sm text-gray-500" dir="auto">
-          {translate('copyright.line2')}
+          {translate('global.copyright.line2')}
         </p>
       </div>
     </footer>

--- a/src/components/footer/index.jsx
+++ b/src/components/footer/index.jsx
@@ -61,7 +61,9 @@ const Footer = ({ pageContext: { locale: language } }) => {
             href="https://twitter.com/rocky_linux"
             className="text-gray-600 dark:text-gray-400 hover:text-gray-500 dark:hover:text-white"
           >
-            <span className="sr-only">{translate('global.socials.twitter')}</span>
+            <span className="sr-only">
+              {translate('global.socials.twitter')}
+            </span>
             <svg
               className="h-6 w-6"
               fill="currentColor"
@@ -75,7 +77,9 @@ const Footer = ({ pageContext: { locale: language } }) => {
             href="https://reddit.com/r/rockylinux"
             className="text-gray-600 dark:text-gray-400 hover:text-gray-500 dark:hover:text-white"
           >
-            <span className="sr-only">{translate('global.socials.reddit')}</span>
+            <span className="sr-only">
+              {translate('global.socials.reddit')}
+            </span>
             <svg
               className="h-6 w-6"
               fill="currentColor"
@@ -89,7 +93,9 @@ const Footer = ({ pageContext: { locale: language } }) => {
             href="https://forums.rockylinux.org/"
             className="text-gray-600 dark:text-gray-400 hover:text-gray-500 dark:hover:text-white"
           >
-            <span className="sr-only">{translate('global.socials.forums')}</span>
+            <span className="sr-only">
+              {translate('global.socials.forums')}
+            </span>
             <svg
               className="h-6 w-6"
               fill="currentColor"
@@ -104,7 +110,9 @@ const Footer = ({ pageContext: { locale: language } }) => {
             href="https://chat.rockylinux.org/"
             className="text-gray-600 dark:text-gray-400 hover:text-gray-500 dark:hover:text-white"
           >
-            <span className="sr-only">{translate('global.socials.mattermost')}</span>
+            <span className="sr-only">
+              {translate('global.socials.mattermost')}
+            </span>
             <svg
               className="h-6 w-6"
               fill="currentColor"
@@ -118,7 +126,9 @@ const Footer = ({ pageContext: { locale: language } }) => {
             href="https://github.com/rocky-linux"
             className="text-gray-600 dark:text-gray-400 hover:text-gray-500 dark:hover:text-white"
           >
-            <span className="sr-only">{translate('global.socials.github')}</span>
+            <span className="sr-only">
+              {translate('global.socials.github')}
+            </span>
             <svg
               className="h-6 w-6"
               fill="currentColor"

--- a/src/components/footer/index.jsx
+++ b/src/components/footer/index.jsx
@@ -224,7 +224,7 @@ const Footer = ({ pageContext: { locale: language } }) => {
               to="/community-charter/"
               className="text-sm text-gray-500 hover:text-gray-400"
             >
-              Community Charter
+              {translate('links.com_charter')}
             </LocalizedLink>
           </div>
           <div className="px-5 py-2">
@@ -232,7 +232,7 @@ const Footer = ({ pageContext: { locale: language } }) => {
               to="/organizational-structure/"
               className="text-sm text-gray-500 hover:text-gray-400"
             >
-              Organizational Structure
+              {translate('links.org_structure')}
             </LocalizedLink>
           </div>
           <div className="px-5 py-2">
@@ -240,7 +240,7 @@ const Footer = ({ pageContext: { locale: language } }) => {
               to="/privacy-policy/"
               className="text-sm text-gray-500 hover:text-gray-400"
             >
-              Privacy Policy
+              {translate('links.privacy')}
             </LocalizedLink>
           </div>
         </nav>

--- a/src/components/header/index.jsx
+++ b/src/components/header/index.jsx
@@ -42,31 +42,31 @@ const Header = ({ pageContext: { locale: language } }) => {
             to="/news/1/"
             className="font-medium text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-50"
           >
-            {translate('links.posts')}
+            {translate('global.links.posts')}
           </LocalizedLink>
           <a
             href="https://wiki.rockylinux.org/"
             className="font-medium text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-50"
           >
-            {translate('links.documentation')}
+            {translate('global.links.wiki')}
           </a>
           <a
             href="https://forums.rockylinux.org/"
             className="font-medium text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-50"
           >
-            {translate('socials.forums')}
+            {translate('global.socials.forums')}
           </a>
           <a
             href="https://www.mucklesu.com/collections/rocky-linux"
             className="font-medium text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-50"
           >
-            {translate('links.store')}
+            {translate('global.links.store')}
           </a>
           <a
             href="https://rockylinux.z2systems.com/np/clients/rockylinux/donation.jsp"
             className="font-medium text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-50"
           >
-            {translate('links.donate')}
+            {translate('global.links.donate')}
           </a>
         </ul>
         <ul className="flex items-center hidden space-x-8 lg:flex">
@@ -92,7 +92,7 @@ const Header = ({ pageContext: { locale: language } }) => {
                   d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
                 />{' '}
               </svg>
-              {translate('links.download')}
+              {translate('global.links.download')}
             </LocalizedLink>
           </li>
         </ul>
@@ -186,7 +186,7 @@ const Header = ({ pageContext: { locale: language } }) => {
                         title="News"
                         className="font-medium tracking-wide text-gray-700 dark:text-white transition-colors duration-200 hover:text-green-500"
                       >
-                        News
+                        {translate('global.links.posts')}
                       </LocalizedLink>
                     </li>
                     <li>
@@ -196,7 +196,7 @@ const Header = ({ pageContext: { locale: language } }) => {
                         title="Wiki"
                         className="font-medium tracking-wide text-gray-700 dark:text-white transition-colors duration-200 hover:text-green-500"
                       >
-                        Wiki
+                        {translate('global.links.wiki')}
                       </a>
                     </li>
                     <li>
@@ -206,7 +206,7 @@ const Header = ({ pageContext: { locale: language } }) => {
                         title="Forums"
                         className="font-medium tracking-wide text-gray-700 dark:text-white transition-colors duration-200 hover:text-green-500"
                       >
-                        Forums
+                        {translate('global.socials.forums')}
                       </a>
                     </li>
                     <li>
@@ -216,7 +216,7 @@ const Header = ({ pageContext: { locale: language } }) => {
                         title="Store"
                         className="font-medium tracking-wide text-gray-700 dark:text-white transition-colors duration-200 hover:text-green-500"
                       >
-                        Store
+                        {translate('global.links.store')}
                       </a>
                     </li>
                     <li>
@@ -226,7 +226,7 @@ const Header = ({ pageContext: { locale: language } }) => {
                         title="Donate"
                         className="font-medium tracking-wide text-gray-700 dark:text-white transition-colors duration-200 hover:text-green-500"
                       >
-                        Donate
+                        {translate('global.links.donate')}
                       </a>
                     </li>
                     <li>
@@ -251,7 +251,7 @@ const Header = ({ pageContext: { locale: language } }) => {
                             d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
                           />{' '}
                         </svg>
-                        {translate('links.download')}
+                        {translate('global.links.download')}
                       </LocalizedLink>
                     </li>
                   </ul>

--- a/src/i18n/locales/ar/translation.json
+++ b/src/i18n/locales/ar/translation.json
@@ -1,72 +1,241 @@
 {
   "language": "ar",
-  "copyright": {
-    "line1": ".٢٠٢٠ مشروع روكي لينكس. كل الحقوق محفوظة ©",
-    "line2": "سينتوس هو علامة تجارية مسجلة لشركة ريد هات. مشروع روكي لينكس لايتبع ولا مؤيد من شركة ريد هات."
-  },
-  "errors": {
-    "404": {
-      "explanation": "تعذر العثور على المورد المطلوب. حاول مرة اخرى.",
-      "title": "الصفحة غير موجودة."
+
+  "global": {
+
+    "copyright": {
+      "line1": ".٢٠٢٠ مشروع روكي لينكس. كل الحقوق محفوظة ©",
+      "line2": "سينتوس هو علامة تجارية مسجلة لشركة ريد هات. مشروع روكي لينكس لايتبع ولا مؤيد من شركة ريد هات."
+    },
+
+    "links": {
+      "close-menu": "إغلاق القائمة",
+      "wiki": "Wiki",
+      "get-in-touch": "تواصل معنا",
+      "get-involved": "شارك",
+      "go-home": "الصفحة الرئيسية",
+      "join-the-discussion": "انضم إلى النقاش",
+      "posts": "News",
+      "show-your-interest": "Show Your Interest",
+      "sponsors": "Sponsors",
+      "partners": "Partners",
+      "status": "Service Status",
+      "donate": "Donate",
+      "store": "Store",
+      "press": "Press",
+      "download": "Download",
+      "com_charter": "Community Charter",
+      "org_structure": "Organization Structure",
+      "privacy": "Privacy Policy",
+      "see-more": "See More",
+      "see-all": "See All",
+      "documentation": "الوثائق",
+      "bug-report": "Report a bug"
+    },
+    "socials": {
+      "forums": "المنتديات",
+      "github": "جيت هب",
+      "reddit": "رديت",
+      "mattermost": "Mattermost",
+      "twitter": "تويتر"
     }
   },
-  "faq": {
-    "a": {
-      "come-in": "يهدف روكي لينكس للعمل كنظام تشغيل مصب كما كان سينتوس فى الماضي, سيتم بناء الاصدارات بعد اضافتها من قبل المنبع, ليس قبله",
-      "downstream-partner-direction": "اعلن مشروع سينتوس عن تغير فى الاستارتيجه لنظام تشغيل سينتوس. لقد كان نظام تشغيل سينتوس يعمل لمصب من المنبع الرئيسي (يتلقي التحديثات و الاصلاحات بعد تطبيقها فو المنبع)، فسوف يتم تغيها ليصبح سينتوس هو المنبع و المصدر ( سينم تجربه الاصلاحات و التحديثات قبل اضافتها للمصدر المدعوم). بالاضافه، تم تقليص الدعم لاصدار ٨ من سينتوس، من ٣١ مايو ٢٠٢٩ ال ٣١ ديسمبر ٢٠٢١."
+
+  "homepage": {
+    "landing": {
+      "p1": {
+        "heading": "روكي لينكس",
+        "content": "مجهود نابع من المجتمع ليقدم لك نظام تشغيل لينكس علي مستوى المؤسسات و جاهز للعمل فى بيئه الانتاج."
+      },
+      "p2": {
+        "heading": "ما هو مشروع روكي لينكس؟",
+        "content": "روكي لينكس نظام تشغيل مجتمعي عالي الكفائه للمؤساسات و مصمم ليكون متوافق  ١٠٠٪  خلل برمجي - خلل برمجي مع افضل توزيعات الينكس للشريكات فى امريكا و التي قد غيرت استراتيجيهتها. و هو الان تحت التطوير المكثف من قبل المجتمع. يقود روكي ليكنس جريجورى كيرتزر ، مؤسس مشروع سينتوس. لايوجد اي توقعات زمنيه  لمتي سيتم الاصدار. يمكن للمساهمون التصال بنا عن طريق وسائل الاتصال المتاحه هنا فى الموقع."
+      }
     },
-    "q": {
-      "come-in": "إذن ، ما هو دور روكي لينكس؟",
-      "downstream-partner-direction": "\"ماذا تعني بان, \"المصدر قد غير اتاجهه و الاستراتيجيه؟"
-    },
-    "title": "أسئلة مكررة"
+    "faq": {
+      "title": "أسئلة مكررة",
+      "a": {
+        "come-in": "يهدف روكي لينكس للعمل كنظام تشغيل مصب كما كان سينتوس فى الماضي, سيتم بناء الاصدارات بعد اضافتها من قبل المنبع, ليس قبله",
+        "downstream-partner-direction": "اعلن مشروع سينتوس عن تغير فى الاستارتيجه لنظام تشغيل سينتوس. لقد كان نظام تشغيل سينتوس يعمل لمصب من المنبع الرئيسي (يتلقي التحديثات و الاصلاحات بعد تطبيقها فو المنبع)، فسوف يتم تغيها ليصبح سينتوس هو المنبع و المصدر ( سينم تجربه الاصلاحات و التحديثات قبل اضافتها للمصدر المدعوم). بالاضافه، تم تقليص الدعم لاصدار ٨ من سينتوس، من ٣١ مايو ٢٠٢٩ ال ٣١ ديسمبر ٢٠٢١."
+      },
+      "q": {
+        "come-in": "إذن ، ما هو دور روكي لينكس؟",
+        "downstream-partner-direction": "\"ماذا تعني بان, \"المصدر قد غير اتاجهه و الاستراتيجيه؟"
+      }
+    }
   },
-  "landing": {
+
+  "download": {
     "p1": {
-      "content": "مجهود نابع من المجتمع ليقدم لك نظام تشغيل لينكس علي مستوى المؤسسات و جاهز للعمل فى بيئه الانتاج.",
-      "heading": "روكي لينكس"
+      "heading": "Downloads",
+      "content": "Download the official release of Rocky Linux from one of our trusted mirrors."
+    },
+    "warning": "The release you can download here is a <i>Release Candidate</i> and should not be used in production. Please check our <a class=\"underline font-medium\" href=\"/faq/\">FAQ</a> for more information.",
+    "table": {
+      "architecture": "Architecture",
+      "iso": "ISOS",
+      "isos": {
+        "minimal": "Minimal",
+        "dvd": "DVD",
+        "boot": "Boot",
+        "checksum": "Checksum"
+      },
+      "packages": "Packages"
     },
     "p2": {
-      "content": "روكي لينكس نظام تشغيل مجتمعي عالي الكفائه للمؤساسات و مصمم ليكون متوافق  ١٠٠٪  خلل برمجي - خلل برمجي مع افضل توزيعات الينكس للشريكات فى امريكا و التي قد غيرت استراتيجيهتها. و هو الان تحت التطوير المكثف من قبل المجتمع. يقود روكي ليكنس جريجورى كيرتزر ، مؤسس مشروع سينتوس. لايوجد اي توقعات زمنيه  لمتي سيتم الاصدار. يمكن للمساهمون التصال بنا عن طريق وسائل الاتصال المتاحه هنا فى الموقع.",
-      "heading": "ما هو مشروع روكي لينكس؟"
+      "content": "As you download and use Rocky Linux, the Rocky Enterprise Software Foundation invites you to <a class=\"text-green-600 dark:text-green-500 font-medium\" href=\"https://chat.rockylinux.org/\">be a part of the community as a contributor</a>. There are many ways to contribute to the project, from documentation, QA, and testing to coding changes for SIGs, providing mirroring or hosting, and helping other users."
     }
   },
+
   "lang": {
     "footer": {
       "choose-language": "اختر لغة..."
     }
   },
-  "links": {
-    "close-menu": "إغلاق القائمة",
-    "documentation": "الوثائق",
-    "get-in-touch": "تواصل معنا",
-    "get-involved": "شارك",
-    "go-home": "الصفحة الرئيسية",
-    "join-the-discussion": "انضم إلى النقاش",
-    "posts": "News",
-    "show-your-interest": "Show Your Interest",
-    "sponsors": "Sponsors",
-    "donate": "Donate",
-    "store": "Store",
-    "press": "Press"
+
+  "errors": {
+    "404": {
+      "title": "الصفحة غير موجودة.",
+      "explanation": "تعذر العثور على المورد المطلوب. حاول مرة اخرى."
+    }
   },
-  "socials": {
-    "forums": "المنتديات",
-    "github": "جيت هب",
-    "reddit": "رديت",
-    "mattermost": "Mattermost",
-    "twitter": "تويتر"
-  },
+
   "news": {
     "title": "News",
     "description": "Stay up-to-date on the latest from The Rocky Linux Project."
   },
+
   "press": {
     "title": "Press",
     "description": "See the latest about Rocky in the press."
   },
+
   "sponsors": {
     "title": "Sponsors",
-    "description": "We would like to thank our sponsors for their support thus far on the project."
+    "description": "We would like to thank our sponsors for their support thus far on the project.",
+    "tag": {
+      "fsponsor": "Founding Sponsor",
+      "psponsor": "Principal Sponsor"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "45drives": {
+        "name": "45Drives",
+        "description": "45Drives offers enterprise storage solutions built on powerful & robust open-source software that allows customers to benefit from the cost savings & flexibility of off-the-shelf hardware. Check them out for a fully supported data storage solution at the best cost per terabyte!"
+      },
+      "opendrives": {
+        "name": "OpenDrives",
+        "description": "OpenDrives is a global provider of enterprise-grade, hyper-scalable, network-attached-storage (NAS) solutions. We deliver the highest performing solutions for our customers - to match individual performance needs - for the most robust, complex and mission-critical projects and workflows, on-premises and into the cloud."
+      },
+      "montavista": {
+        "name": "MontaVista",
+        "description": "MontaVista Software is the leader in embedded commercial Linux, supporting MontaVista CGX, Yocto Project®, CentOS and Rocky Linux. MontaVista offers Open Source Software expertise, commercial-quality Linux distros, cost-effective maintenance and support for 10+ year life-cycles."
+      },
+      "aws": {
+        "name": "Amazon Web Services",
+        "description": "The RESF utilizes AWS to run much of the underlying infrastructure critical to the development and deployment of the services supporting Rocky Linux. From Koji builders for x86_64 and aarch64 running in EC2 to SRPM blob storage in S3, AWS is foundational to much of what we do."
+      }
+    }
+  },
+
+  "partners": {
+    "title": "Partners",
+    "description": "Partners of the RESF represent ongoing relationships of strategic importance to the Rocky Linux project. Through dedication of engineering expertise, infrastructure resources, or other means, their support is critical to our continued success and long term stability.",
+    "tag": {
+      "fpartner": "Founding Partner",
+      "ppartner": "Principal Partner"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "navercloud": {
+        "name": "NAVER Cloud",
+        "description": "NAVER Cloud Platform is a South Korean cloud service that started in 2017 under NAVER Cloud, a subsidiary of NAVER. It provides over 170 individual services in 2021 and holds various security certifications including CSA STAR GOLD, GDPR, and more. It also currently provides cloud services in 10 locations around the world."
+      },
+      "mattermost": {
+        "name": "Mattermost",
+        "description": "Mattermost is an open source messaging solution made for organizations with the highest security requirements. As big believers in the power of open source, Mattermost is thrilled to partner with RESF to help bring an enterprise-grade distribution of Linux to the tech community."
+      }
+    }
+  },
+
+  "faq": {
+    "heading": "Frequently Asked Questions",
+    "q1": {
+      "q": "Where can I download the release candidate?",
+      "a": "https://rockylinux.org/download"
+    },
+    "q2": {
+      "q": "What is a release candidate?",
+      "a": "A release candidate is a beta version of a product that has the potential to be stable.The intent of a release candidate is for the community to test and validate expected functionality of Rocky Linux and report any bugs if present."
+    },
+    "q3": {
+      "q": "Can I use the release candidate in production?",
+      "a": "Under no circumstance should you use a release candidate in a production environment. A release candidate is provided for testing and validation purposes only."
+    },
+    "q4": {
+      "q": "How can I help mirror the release candidate and future Rocky Linux releases?",
+      "a": "Please email <a href=\"mailto:mirrors@rockylinux.org\">mirrors@rockylinux.org</a> to express your interest."
+    },
+    "q5": {
+      "q": "I encountered a bug while testing the release candidate, what can I do?",
+      "a": "First, create an account using <a href=\"https://accounts.rockylinux.org/\"> Rocky Linux Account Services </a> , then head over to our <a href=\"https://bugs.rockylinux.org/\">Bugzilla server</a> to report any bugs."
+    },
+    "q6": {
+      "q": "How can I get involved with the Testing team?",
+      "a": "Please join the <a href=\"https://chat.rockylinux.org/rocky-linux/channels/testing\"> ~Testing </a> channel on our Mattermost server to get started. There’s also a testing topic on the forums for more durable conversation."
+    },
+    "q7": {
+      "q": "Where can I find the latest news about Rocky Linux?",
+      "a": "Stay tuned to our website, Twitter, LinkedIn, forums, and other platforms listed in our link directory for the latest announcements."
+    },
+    "q8": {
+      "q": "If Rocky Linux is just a respin of RHEL, what took so long for a release candidate?",
+      "a1": "If our only goal for Rocky Linux was to debrand and repackage RHEL, we would have been done much sooner. However, what we had to do differently is figure out how we could keep Rocky Linux in the hands of the community. Carefully devising this strategy ensures that Rocky Linux will never meet the same fate of CentOS.",
+      "a2": "The goal was not just to create a community managed RPM based distribution of Linux, but to ensure that it will remain freely available and always in the control of the community, much like Linux itself has. To do that required more than a build infrastructure; it required that we put in place the foundational structures that enable the community, ensuring that Rocky Linux is forever inclusive, free, and open. The infrastructure is built from the ground up by many collaborators and sponsoring organizations around composability and security compliance, providing the substrate for not only the base operating system but also an entire community of diverse interests to take part in the project."
+    },
+    "q9": {
+      "q": "If you’re not just repackaging RHEL, then what exactly are you doing?",
+      "a": "Our goal is to maintain Rocky Linux as a community-oriented distribution <i>by</i> the community, <i>for</i> the community. To do this, we are establishing the necessary organizational structures to ensure that Rocky Linux remains in the hands of the community. We want to make sure that it’s not possible for what happened to CentOS to happen to Rocky Linux."
+    },
+    "q10": {
+      "q": "How will you ensure that Rocky Linux truly remains a community enterprise operating system?",
+      "a": "First, we’ve taken steps to legally protect the Rocky Linux name. This means registering its trademarks and various associated properties to protect them from being controlled by another entity. We’ve achieved this by establishing them under the Rocky Enterprise Software Foundation (RESF). Next, we’re drafting a community charter that will define the organizational structure, objectives, values, and mission behind the legal entity that represents Rocky Linux. Critical in this charter is the establishment of principles that enable and protect the community: transparency, community involvement, open development, and independence. <strong> Rocky Linux will never be controlled, purchased, or otherwise influenced by a single entity or organization. </strong> Finally, we’re architecting and deploying the necessary infrastructure to further enable the community to contribute to Rocky Linux."
+    },
+    "q11": {
+      "q": "What infrastructure is necessary to enable the community?",
+      "a1": "We’ve established a number of teams to support the various efforts associated with developing Rocky Linux:",
+      "a2": "You can read more about this structure when it’s soon published. In order to enable collaboration across and within those teams, we needed to deploy our own chat infrastructure, forums, and website. Additionally, we’re also creating our build infrastructure, which will facilitate the development of the core operating system.",
+      "list": {
+        "community": "Community",
+        "core-inf": "Core Infrastructure",
+        "design": "Design",
+        "documentation": "Documentation",
+        "installer": "Installer",
+        "leadership": "Leadership",
+        "pkg-autob": "Package Auto-Builders",
+        "packaging": "Packaging",
+        "security": "Security",
+        "sigs": "Special Interest Groups (SIGs)",
+        "web": "Web"
+      }
+    },
+    "q12": {
+      "q": "Why does it take so much time to stand up a community and build infrastructure?",
+      "a": "It’s not terribly difficult to deploy a website, forums, or a build infrastructure in a reliable fashion. Our chat program for instance, which uses Mattermost, is distributed on a number of application servers behind a load balancer and was ready in just a couple of weeks. But it does require careful thought and planning to do it in a scalable and secure manner when you need to ensure vendor and platform agnosticity and long-term community involvement."
+    },
+    "q13": {
+      "q": "So what’s the short answer to all of this? What are some things you’re thinking about as you put Rocky Linux together?",
+      "a": "How do we carefully shepherd community trust? How do we ensure that anyone who wants to participate can not only do so immediately, but forever in the future as well? How do we engage and enable the community members who might not be as technical but want to contribute anyway? Solving for all of these challenges will take time, and we would love your help in doing so."
+    },
+    "q14": {
+      "q": "What if I have feedback or my question wasn’t answered here?",
+      "a": "Please email us: <a href=\"mailto:hello@rockylinux.org\">hello@rockylinux.org</a> and we’ll get back to you as soon as we can."
+    }
   }
 }

--- a/src/i18n/locales/ca/translation.json
+++ b/src/i18n/locales/ca/translation.json
@@ -1,72 +1,241 @@
 {
   "language": "ca",
-  "copyright": {
-    "line1": "© 2021 The Rocky Linux Project. Tots els drets reservats.",
-    "line2": "CentOS és una marca registrada de Red Hat, Inc. El Projecte Rocky Linux no està afiliat ni té cap mena de suport per part de Red Hat, Inc."
-  },
-  "errors": {
-    "404": {
-      "explanation": "No es trova el recurs sol·licitat. Prova de nou",
-      "title": "Pàgina no trovada."
+
+  "global": {
+
+    "copyright": {
+      "line1": "© 2021 The Rocky Linux Project. Tots els drets reservats.",
+      "line2": "CentOS és una marca registrada de Red Hat, Inc. El Projecte Rocky Linux no està afiliat ni té cap mena de suport per part de Red Hat, Inc."
+    },
+
+    "links": {
+      "close-menu": "Tanca el menú",
+      "wiki": "Wiki",
+      "get-in-touch": "Estigues en contacte",
+      "get-involved": "Participa",
+      "go-home": "Inici",
+      "join-the-discussion": "Uneix-te al debat",
+      "posts": "News",
+      "show-your-interest": "Show Your Interest",
+      "sponsors": "Sponsors",
+      "partners": "Partners",
+      "status": "Service Status",
+      "donate": "Donate",
+      "store": "Store",
+      "press": "Press",
+      "download": "Download",
+      "com_charter": "Community Charter",
+      "org_structure": "Organization Structure",
+      "privacy": "Privacy Policy",
+      "see-more": "See More",
+      "see-all": "See All",
+      "documentation": "Documentació",
+      "bug-report": "Report a bug"
+    },
+    "socials": {
+      "forums": "Forums",
+      "github": "Github",
+      "reddit": "Reddit",
+      "mattermost": "Mattermost",
+      "twitter": "Twitter"
     }
   },
-  "faq": {
-    "a": {
-      "come-in": "L'objectiu de Rocky Linux és funcionar com una compilació descendent com havia estat CentOS anteriorment, construint versions després d'haver-les agregat pel seu proveïdor ascendent, no abans.",
-      "downstream-partner-direction": "El projecte CentOS va anunciar recentment un canvi en l'estratègia de CentOS. Anteriorment CentOS existia com una compilació descendent del seu proveïdor ascendent, això és, rebia pedaços i actualitzacions després que ho fes el seu proveïdor ascendent. Ara passarà a ser una compilació ascendent, és a dir, provarà pedaços i actualitzacions abans d'afegir-los al seu proveïdor ascendent. A més, el suport per la CentOS Linux 8 ha estat interromput, canviant el final del suport del 31 de maig del 2029 al 31 de desembre del 2021."
+
+  "homepage": {
+    "landing": {
+      "p1": {
+        "heading": "Rocky Linux",
+        "content": "Un esforç de la comunitat per obtenir un sistema de classe empresarial llest per producció"
+      },
+      "p2": {
+        "heading": "Què és el projecte Rocky Linux?",
+        "content": "Rocky Linux és un sistema operatiu empresarial comunitari dissenyat per ser 100% compatible amb la distribució de Linux empresarial més important dels Estats Units ara que el seu soci intermedi ha canviat de direcció. Està en desenvolupament intensiu per part de la comunitat. Rocky Linux està sota el comandament d'en Gregory Kutzer, fundador del projecte CentOS. No hi ha una data estimada pel llançament. Se sol·licita als col·laboradors que es comuniquin amb les opcions que s'ofereixen en aquest lloc web."
+      }
     },
-    "q": {
-      "come-in": "LLavors, quin és el paper de Rocky Linux?",
-      "downstream-partner-direction": "Què vol dir «El seu soci anterior ha canviat de direcció»?"
-    },
-    "title": "Preguntes més freqüents"
+    "faq": {
+      "title": "Preguntes més freqüents",
+      "a": {
+        "come-in": "L'objectiu de Rocky Linux és funcionar com una compilació descendent com havia estat CentOS anteriorment, construint versions després d'haver-les agregat pel seu proveïdor ascendent, no abans.",
+        "downstream-partner-direction": "El projecte CentOS va anunciar recentment un canvi en l'estratègia de CentOS. Anteriorment CentOS existia com una compilació descendent del seu proveïdor ascendent, això és, rebia pedaços i actualitzacions després que ho fes el seu proveïdor ascendent. Ara passarà a ser una compilació ascendent, és a dir, provarà pedaços i actualitzacions abans d'afegir-los al seu proveïdor ascendent. A més, el suport per la CentOS Linux 8 ha estat interromput, canviant el final del suport del 31 de maig del 2029 al 31 de desembre del 2021."
+      },
+      "q": {
+        "come-in": "LLavors, quin és el paper de Rocky Linux?",
+        "downstream-partner-direction": "Què vol dir «El seu soci anterior ha canviat de direcció»?"
+      }
+    }
   },
-  "landing": {
+
+  "download": {
     "p1": {
-      "content": "Un esforç de la comunitat per obtenir un sistema de classe empresarial llest per producció",
-      "heading": "Rocky Linux"
+      "heading": "Downloads",
+      "content": "Download the official release of Rocky Linux from one of our trusted mirrors."
+    },
+    "warning": "The release you can download here is a <i>Release Candidate</i> and should not be used in production. Please check our <a class=\"underline font-medium\" href=\"/faq/\">FAQ</a> for more information.",
+    "table": {
+      "architecture": "Architecture",
+      "iso": "ISOS",
+      "isos": {
+        "minimal": "Minimal",
+        "dvd": "DVD",
+        "boot": "Boot",
+        "checksum": "Checksum"
+      },
+      "packages": "Packages"
     },
     "p2": {
-      "content": "Rocky Linux és un sistema operatiu empresarial comunitari dissenyat per ser 100% compatible amb la distribució de Linux empresarial més important dels Estats Units ara que el seu soci intermedi ha canviat de direcció. Està en desenvolupament intensiu per part de la comunitat. Rocky Linux està sota el comandament d'en Gregory Kutzer, fundador del projecte CentOS. No hi ha una data estimada pel llançament. Se sol·licita als col·laboradors que es comuniquin amb les opcions que s'ofereixen en aquest lloc web.",
-      "heading": "Què és el projecte Rocky Linux?"
+      "content": "As you download and use Rocky Linux, the Rocky Enterprise Software Foundation invites you to <a class=\"text-green-600 dark:text-green-500 font-medium\" href=\"https://chat.rockylinux.org/\">be a part of the community as a contributor</a>. There are many ways to contribute to the project, from documentation, QA, and testing to coding changes for SIGs, providing mirroring or hosting, and helping other users."
     }
   },
+
   "lang": {
     "footer": {
       "choose-language": "Escull l'idioma..."
     }
   },
-  "links": {
-    "close-menu": "Tanca el menú",
-    "documentation": "Documentació",
-    "get-in-touch": "Estigues en contacte",
-    "get-involved": "Participa",
-    "go-home": "Inici",
-    "join-the-discussion": "Uneix-te al debat",
-    "posts": "News",
-    "show-your-interest": "Show Your Interest",
-    "sponsors": "Sponsors",
-    "donate": "Donate",
-    "store": "Store",
-    "press": "Press"
+
+  "errors": {
+    "404": {
+      "title": "Pàgina no trovada.",
+      "explanation": "No es trova el recurs sol·licitat. Prova de nou"
+    }
   },
-  "socials": {
-    "forums": "Forums",
-    "github": "Github",
-    "reddit": "Reddit",
-    "mattermost": "Mattermost",
-    "twitter": "Twitter"
-  },
+
   "news": {
     "title": "News",
     "description": "Stay up-to-date on the latest from The Rocky Linux Project."
   },
+
   "press": {
     "title": "Press",
     "description": "See the latest about Rocky in the press."
   },
+
   "sponsors": {
     "title": "Sponsors",
-    "description": "We would like to thank our sponsors for their support thus far on the project."
+    "description": "We would like to thank our sponsors for their support thus far on the project.",
+    "tag": {
+      "fsponsor": "Founding Sponsor",
+      "psponsor": "Principal Sponsor"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "45drives": {
+        "name": "45Drives",
+        "description": "45Drives offers enterprise storage solutions built on powerful & robust open-source software that allows customers to benefit from the cost savings & flexibility of off-the-shelf hardware. Check them out for a fully supported data storage solution at the best cost per terabyte!"
+      },
+      "opendrives": {
+        "name": "OpenDrives",
+        "description": "OpenDrives is a global provider of enterprise-grade, hyper-scalable, network-attached-storage (NAS) solutions. We deliver the highest performing solutions for our customers - to match individual performance needs - for the most robust, complex and mission-critical projects and workflows, on-premises and into the cloud."
+      },
+      "montavista": {
+        "name": "MontaVista",
+        "description": "MontaVista Software is the leader in embedded commercial Linux, supporting MontaVista CGX, Yocto Project®, CentOS and Rocky Linux. MontaVista offers Open Source Software expertise, commercial-quality Linux distros, cost-effective maintenance and support for 10+ year life-cycles."
+      },
+      "aws": {
+        "name": "Amazon Web Services",
+        "description": "The RESF utilizes AWS to run much of the underlying infrastructure critical to the development and deployment of the services supporting Rocky Linux. From Koji builders for x86_64 and aarch64 running in EC2 to SRPM blob storage in S3, AWS is foundational to much of what we do."
+      }
+    }
+  },
+
+  "partners": {
+    "title": "Partners",
+    "description": "Partners of the RESF represent ongoing relationships of strategic importance to the Rocky Linux project. Through dedication of engineering expertise, infrastructure resources, or other means, their support is critical to our continued success and long term stability.",
+    "tag": {
+      "fpartner": "Founding Partner",
+      "ppartner": "Principal Partner"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "navercloud": {
+        "name": "NAVER Cloud",
+        "description": "NAVER Cloud Platform is a South Korean cloud service that started in 2017 under NAVER Cloud, a subsidiary of NAVER. It provides over 170 individual services in 2021 and holds various security certifications including CSA STAR GOLD, GDPR, and more. It also currently provides cloud services in 10 locations around the world."
+      },
+      "mattermost": {
+        "name": "Mattermost",
+        "description": "Mattermost is an open source messaging solution made for organizations with the highest security requirements. As big believers in the power of open source, Mattermost is thrilled to partner with RESF to help bring an enterprise-grade distribution of Linux to the tech community."
+      }
+    }
+  },
+
+  "faq": {
+    "heading": "Frequently Asked Questions",
+    "q1": {
+      "q": "Where can I download the release candidate?",
+      "a": "https://rockylinux.org/download"
+    },
+    "q2": {
+      "q": "What is a release candidate?",
+      "a": "A release candidate is a beta version of a product that has the potential to be stable.The intent of a release candidate is for the community to test and validate expected functionality of Rocky Linux and report any bugs if present."
+    },
+    "q3": {
+      "q": "Can I use the release candidate in production?",
+      "a": "Under no circumstance should you use a release candidate in a production environment. A release candidate is provided for testing and validation purposes only."
+    },
+    "q4": {
+      "q": "How can I help mirror the release candidate and future Rocky Linux releases?",
+      "a": "Please email <a href=\"mailto:mirrors@rockylinux.org\">mirrors@rockylinux.org</a> to express your interest."
+    },
+    "q5": {
+      "q": "I encountered a bug while testing the release candidate, what can I do?",
+      "a": "First, create an account using <a href=\"https://accounts.rockylinux.org/\"> Rocky Linux Account Services </a> , then head over to our <a href=\"https://bugs.rockylinux.org/\">Bugzilla server</a> to report any bugs."
+    },
+    "q6": {
+      "q": "How can I get involved with the Testing team?",
+      "a": "Please join the <a href=\"https://chat.rockylinux.org/rocky-linux/channels/testing\"> ~Testing </a> channel on our Mattermost server to get started. There’s also a testing topic on the forums for more durable conversation."
+    },
+    "q7": {
+      "q": "Where can I find the latest news about Rocky Linux?",
+      "a": "Stay tuned to our website, Twitter, LinkedIn, forums, and other platforms listed in our link directory for the latest announcements."
+    },
+    "q8": {
+      "q": "If Rocky Linux is just a respin of RHEL, what took so long for a release candidate?",
+      "a1": "If our only goal for Rocky Linux was to debrand and repackage RHEL, we would have been done much sooner. However, what we had to do differently is figure out how we could keep Rocky Linux in the hands of the community. Carefully devising this strategy ensures that Rocky Linux will never meet the same fate of CentOS.",
+      "a2": "The goal was not just to create a community managed RPM based distribution of Linux, but to ensure that it will remain freely available and always in the control of the community, much like Linux itself has. To do that required more than a build infrastructure; it required that we put in place the foundational structures that enable the community, ensuring that Rocky Linux is forever inclusive, free, and open. The infrastructure is built from the ground up by many collaborators and sponsoring organizations around composability and security compliance, providing the substrate for not only the base operating system but also an entire community of diverse interests to take part in the project."
+    },
+    "q9": {
+      "q": "If you’re not just repackaging RHEL, then what exactly are you doing?",
+      "a": "Our goal is to maintain Rocky Linux as a community-oriented distribution <i>by</i> the community, <i>for</i> the community. To do this, we are establishing the necessary organizational structures to ensure that Rocky Linux remains in the hands of the community. We want to make sure that it’s not possible for what happened to CentOS to happen to Rocky Linux."
+    },
+    "q10": {
+      "q": "How will you ensure that Rocky Linux truly remains a community enterprise operating system?",
+      "a": "First, we’ve taken steps to legally protect the Rocky Linux name. This means registering its trademarks and various associated properties to protect them from being controlled by another entity. We’ve achieved this by establishing them under the Rocky Enterprise Software Foundation (RESF). Next, we’re drafting a community charter that will define the organizational structure, objectives, values, and mission behind the legal entity that represents Rocky Linux. Critical in this charter is the establishment of principles that enable and protect the community: transparency, community involvement, open development, and independence. <strong> Rocky Linux will never be controlled, purchased, or otherwise influenced by a single entity or organization. </strong> Finally, we’re architecting and deploying the necessary infrastructure to further enable the community to contribute to Rocky Linux."
+    },
+    "q11": {
+      "q": "What infrastructure is necessary to enable the community?",
+      "a1": "We’ve established a number of teams to support the various efforts associated with developing Rocky Linux:",
+      "a2": "You can read more about this structure when it’s soon published. In order to enable collaboration across and within those teams, we needed to deploy our own chat infrastructure, forums, and website. Additionally, we’re also creating our build infrastructure, which will facilitate the development of the core operating system.",
+      "list": {
+        "community": "Community",
+        "core-inf": "Core Infrastructure",
+        "design": "Design",
+        "documentation": "Documentation",
+        "installer": "Installer",
+        "leadership": "Leadership",
+        "pkg-autob": "Package Auto-Builders",
+        "packaging": "Packaging",
+        "security": "Security",
+        "sigs": "Special Interest Groups (SIGs)",
+        "web": "Web"
+      }
+    },
+    "q12": {
+      "q": "Why does it take so much time to stand up a community and build infrastructure?",
+      "a": "It’s not terribly difficult to deploy a website, forums, or a build infrastructure in a reliable fashion. Our chat program for instance, which uses Mattermost, is distributed on a number of application servers behind a load balancer and was ready in just a couple of weeks. But it does require careful thought and planning to do it in a scalable and secure manner when you need to ensure vendor and platform agnosticity and long-term community involvement."
+    },
+    "q13": {
+      "q": "So what’s the short answer to all of this? What are some things you’re thinking about as you put Rocky Linux together?",
+      "a": "How do we carefully shepherd community trust? How do we ensure that anyone who wants to participate can not only do so immediately, but forever in the future as well? How do we engage and enable the community members who might not be as technical but want to contribute anyway? Solving for all of these challenges will take time, and we would love your help in doing so."
+    },
+    "q14": {
+      "q": "What if I have feedback or my question wasn’t answered here?",
+      "a": "Please email us: <a href=\"mailto:hello@rockylinux.org\">hello@rockylinux.org</a> and we’ll get back to you as soon as we can."
+    }
   }
 }

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -1,72 +1,241 @@
 {
   "language": "de",
-  "copyright": {
-    "line1": "© 2021 The Rocky Linux Project. Alle Rechte vorbehalten.",
-    "line2": "CentOS ist ein registriertes Markenzeichen von Red Hat, Inc. Das Rocky Linux-Projekt steht in keinerlei Verbindung zu Red Hat, Inc. und wird auch nicht von ihnen gebilligt."
-  },
-  "errors": {
-    "404": {
-      "explanation": "Die angefragte Resource konnte nicht gefunden werden. Bitte erneut versuchen.",
-      "title": "Seite nicht gefunden."
+
+  "global": {
+
+    "copyright": {
+      "line1": "© 2021 The Rocky Linux Project. Alle Rechte vorbehalten.",
+      "line2": "CentOS ist ein registriertes Markenzeichen von Red Hat, Inc. Das Rocky Linux-Projekt steht in keinerlei Verbindung zu Red Hat, Inc. und wird auch nicht von ihnen gebilligt."
+    },
+
+    "links": {
+      "close-menu": "Schliesse Menü",
+      "wiki": "Wiki",
+      "get-in-touch": "Kontaktiere uns",
+      "get-involved": "Mach mit",
+      "go-home": "Gehe zum Start",
+      "join-the-discussion": "Nimm an der Diskussion teil",
+      "posts": "News",
+      "show-your-interest": "Show Your Interest",
+      "sponsors": "Sponsors",
+      "partners": "Partners",
+      "status": "Service Status",
+      "donate": "Donate",
+      "store": "Store",
+      "press": "Press",
+      "download": "Download",
+      "com_charter": "Community Charter",
+      "org_structure": "Organization Structure",
+      "privacy": "Privacy Policy",
+      "see-more": "See More",
+      "see-all": "See All",
+      "documentation": "Dokumentation",
+      "bug-report": "Report a bug"
+    },
+    "socials": {
+      "forums": "Forums",
+      "github": "Github",
+      "reddit": "Reddit",
+      "mattermost": "Mattermost",
+      "twitter": "Twitter"
     }
   },
-  "faq": {
-    "a": {
-      "come-in": "Rocky Linux zielt darauf ab, wie zuvor bei CentOS, als Downstream-Build zu fungieren und Releases zu veröffentlichen, nachdem sie vom Upstream-Anbieter hinzugefügt wurden, nicht zuvor.",
-      "downstream-partner-direction": "Das CentOS-Projekt hat kürzlich einen Stragegie-Wechsel für CentOS angekündigt. Während CentOS zuvor als Downstream-Build seines Upstream-Anbieters existierte (es erhält Patches und Aktualisierungen, nachdem der Upstream-Anbieter dies getan hat), wird es auf einen Upstream-Build umgestellt (Testen von Patches und Updates vor der Aufnahme in den Upstream-Anbieter). Darüber hinaus wurde die Unterstützung für CentOS Linux 8 vom 31. Mai 2029 bis zum 31. Dezember 2021 eingestellt."
+
+  "homepage": {
+    "landing": {
+      "p1": {
+        "heading": "Rocky Linux",
+        "content": "Eine gemeinschaftlich-getriebene Anstrengung um eine produktionsbereite Linux-Distribution für höchste Ansprüche zu liefern."
+      },
+      "p2": {
+        "heading": "Was ist das Rocky Linux-Projekt?",
+        "content": "Rocky Linux ist ein Community-Betriebssystem für Unternehmen, das zu 100% Bug-for-Bug-kompatibel mit Amerikas führender Linux-Distribution für Unternehmen ist, nachdem sein nachgeschalteter Partner die Richtung geändert hat. Es wird von der Community intensiv weiterentwickelt. Rocky Linux wird von Gregory Kurtzer, dem Gründer des CentOS-Projekts, geleitet. Es gibt keine ETA für eine Veröffentlichung. Die Mitwirkenden werden gebeten, die auf dieser Website angebotenen Kommunikationsoptionen zu nutzen."
+      }
     },
-    "q": {
-      "come-in": "Wo platziert sich Rocky Linux?",
-      "downstream-partner-direction": "Was meinst du damit, dass \"hat sein nachgeschalteter Partner die Richtung geändert\"?"
-    },
-    "title": "Häufig gestellte Fragen"
+    "faq": {
+      "title": "Häufig gestellte Fragen",
+      "a": {
+        "come-in": "Rocky Linux zielt darauf ab, wie zuvor bei CentOS, als Downstream-Build zu fungieren und Releases zu veröffentlichen, nachdem sie vom Upstream-Anbieter hinzugefügt wurden, nicht zuvor.",
+        "downstream-partner-direction": "Das CentOS-Projekt hat kürzlich einen Stragegie-Wechsel für CentOS angekündigt. Während CentOS zuvor als Downstream-Build seines Upstream-Anbieters existierte (es erhält Patches und Aktualisierungen, nachdem der Upstream-Anbieter dies getan hat), wird es auf einen Upstream-Build umgestellt (Testen von Patches und Updates vor der Aufnahme in den Upstream-Anbieter). Darüber hinaus wurde die Unterstützung für CentOS Linux 8 vom 31. Mai 2029 bis zum 31. Dezember 2021 eingestellt."
+      },
+      "q": {
+        "come-in": "Wo platziert sich Rocky Linux?",
+        "downstream-partner-direction": "Was meinst du damit, dass \"hat sein nachgeschalteter Partner die Richtung geändert\"?"
+      }
+    }
   },
-  "landing": {
+
+  "download": {
     "p1": {
-      "content": "Eine gemeinschaftlich-getriebene Anstrengung um eine produktionsbereite Linux-Distribution für höchste Ansprüche zu liefern.",
-      "heading": "Rocky Linux"
+      "heading": "Downloads",
+      "content": "Download the official release of Rocky Linux from one of our trusted mirrors."
+    },
+    "warning": "The release you can download here is a <i>Release Candidate</i> and should not be used in production. Please check our <a class=\"underline font-medium\" href=\"/faq/\">FAQ</a> for more information.",
+    "table": {
+      "architecture": "Architecture",
+      "iso": "ISOS",
+      "isos": {
+        "minimal": "Minimal",
+        "dvd": "DVD",
+        "boot": "Boot",
+        "checksum": "Checksum"
+      },
+      "packages": "Packages"
     },
     "p2": {
-      "content": "Rocky Linux ist ein Community-Betriebssystem für Unternehmen, das zu 100% Bug-for-Bug-kompatibel mit Amerikas führender Linux-Distribution für Unternehmen ist, nachdem sein nachgeschalteter Partner die Richtung geändert hat. Es wird von der Community intensiv weiterentwickelt. Rocky Linux wird von Gregory Kurtzer, dem Gründer des CentOS-Projekts, geleitet. Es gibt keine ETA für eine Veröffentlichung. Die Mitwirkenden werden gebeten, die auf dieser Website angebotenen Kommunikationsoptionen zu nutzen.",
-      "heading": "Was ist das Rocky Linux-Projekt?"
+      "content": "As you download and use Rocky Linux, the Rocky Enterprise Software Foundation invites you to <a class=\"text-green-600 dark:text-green-500 font-medium\" href=\"https://chat.rockylinux.org/\">be a part of the community as a contributor</a>. There are many ways to contribute to the project, from documentation, QA, and testing to coding changes for SIGs, providing mirroring or hosting, and helping other users."
     }
   },
+
   "lang": {
     "footer": {
       "choose-language": "Wähle eine Sprache..."
     }
   },
-  "links": {
-    "close-menu": "Schliesse Menü",
-    "documentation": "Dokumentation",
-    "get-in-touch": "Kontaktiere uns",
-    "get-involved": "Mach mit",
-    "go-home": "Gehe zum Start",
-    "join-the-discussion": "Nimm an der Diskussion teil",
-    "posts": "News",
-    "show-your-interest": "Show Your Interest",
-    "sponsors": "Sponsors",
-    "donate": "Donate",
-    "store": "Store",
-    "press": "Press"
+
+  "errors": {
+    "404": {
+      "title": "Seite nicht gefunden.",
+      "explanation": "Die angefragte Resource konnte nicht gefunden werden. Bitte erneut versuchen."
+    }
   },
-  "socials": {
-    "forums": "Forums",
-    "github": "Github",
-    "reddit": "Reddit",
-    "mattermost": "Mattermost",
-    "twitter": "Twitter"
-  },
+
   "news": {
     "title": "News",
     "description": "Stay up-to-date on the latest from The Rocky Linux Project."
   },
+
   "press": {
     "title": "Press",
     "description": "See the latest about Rocky in the press."
   },
+
   "sponsors": {
     "title": "Sponsors",
-    "description": "We would like to thank our sponsors for their support thus far on the project."
+    "description": "We would like to thank our sponsors for their support thus far on the project.",
+    "tag": {
+      "fsponsor": "Founding Sponsor",
+      "psponsor": "Principal Sponsor"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "45drives": {
+        "name": "45Drives",
+        "description": "45Drives offers enterprise storage solutions built on powerful & robust open-source software that allows customers to benefit from the cost savings & flexibility of off-the-shelf hardware. Check them out for a fully supported data storage solution at the best cost per terabyte!"
+      },
+      "opendrives": {
+        "name": "OpenDrives",
+        "description": "OpenDrives is a global provider of enterprise-grade, hyper-scalable, network-attached-storage (NAS) solutions. We deliver the highest performing solutions for our customers - to match individual performance needs - for the most robust, complex and mission-critical projects and workflows, on-premises and into the cloud."
+      },
+      "montavista": {
+        "name": "MontaVista",
+        "description": "MontaVista Software is the leader in embedded commercial Linux, supporting MontaVista CGX, Yocto Project®, CentOS and Rocky Linux. MontaVista offers Open Source Software expertise, commercial-quality Linux distros, cost-effective maintenance and support for 10+ year life-cycles."
+      },
+      "aws": {
+        "name": "Amazon Web Services",
+        "description": "The RESF utilizes AWS to run much of the underlying infrastructure critical to the development and deployment of the services supporting Rocky Linux. From Koji builders for x86_64 and aarch64 running in EC2 to SRPM blob storage in S3, AWS is foundational to much of what we do."
+      }
+    }
+  },
+
+  "partners": {
+    "title": "Partners",
+    "description": "Partners of the RESF represent ongoing relationships of strategic importance to the Rocky Linux project. Through dedication of engineering expertise, infrastructure resources, or other means, their support is critical to our continued success and long term stability.",
+    "tag": {
+      "fpartner": "Founding Partner",
+      "ppartner": "Principal Partner"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "navercloud": {
+        "name": "NAVER Cloud",
+        "description": "NAVER Cloud Platform is a South Korean cloud service that started in 2017 under NAVER Cloud, a subsidiary of NAVER. It provides over 170 individual services in 2021 and holds various security certifications including CSA STAR GOLD, GDPR, and more. It also currently provides cloud services in 10 locations around the world."
+      },
+      "mattermost": {
+        "name": "Mattermost",
+        "description": "Mattermost is an open source messaging solution made for organizations with the highest security requirements. As big believers in the power of open source, Mattermost is thrilled to partner with RESF to help bring an enterprise-grade distribution of Linux to the tech community."
+      }
+    }
+  },
+
+  "faq": {
+    "heading": "Frequently Asked Questions",
+    "q1": {
+      "q": "Where can I download the release candidate?",
+      "a": "https://rockylinux.org/download"
+    },
+    "q2": {
+      "q": "What is a release candidate?",
+      "a": "A release candidate is a beta version of a product that has the potential to be stable.The intent of a release candidate is for the community to test and validate expected functionality of Rocky Linux and report any bugs if present."
+    },
+    "q3": {
+      "q": "Can I use the release candidate in production?",
+      "a": "Under no circumstance should you use a release candidate in a production environment. A release candidate is provided for testing and validation purposes only."
+    },
+    "q4": {
+      "q": "How can I help mirror the release candidate and future Rocky Linux releases?",
+      "a": "Please email <a href=\"mailto:mirrors@rockylinux.org\">mirrors@rockylinux.org</a> to express your interest."
+    },
+    "q5": {
+      "q": "I encountered a bug while testing the release candidate, what can I do?",
+      "a": "First, create an account using <a href=\"https://accounts.rockylinux.org/\"> Rocky Linux Account Services </a> , then head over to our <a href=\"https://bugs.rockylinux.org/\">Bugzilla server</a> to report any bugs."
+    },
+    "q6": {
+      "q": "How can I get involved with the Testing team?",
+      "a": "Please join the <a href=\"https://chat.rockylinux.org/rocky-linux/channels/testing\"> ~Testing </a> channel on our Mattermost server to get started. There’s also a testing topic on the forums for more durable conversation."
+    },
+    "q7": {
+      "q": "Where can I find the latest news about Rocky Linux?",
+      "a": "Stay tuned to our website, Twitter, LinkedIn, forums, and other platforms listed in our link directory for the latest announcements."
+    },
+    "q8": {
+      "q": "If Rocky Linux is just a respin of RHEL, what took so long for a release candidate?",
+      "a1": "If our only goal for Rocky Linux was to debrand and repackage RHEL, we would have been done much sooner. However, what we had to do differently is figure out how we could keep Rocky Linux in the hands of the community. Carefully devising this strategy ensures that Rocky Linux will never meet the same fate of CentOS.",
+      "a2": "The goal was not just to create a community managed RPM based distribution of Linux, but to ensure that it will remain freely available and always in the control of the community, much like Linux itself has. To do that required more than a build infrastructure; it required that we put in place the foundational structures that enable the community, ensuring that Rocky Linux is forever inclusive, free, and open. The infrastructure is built from the ground up by many collaborators and sponsoring organizations around composability and security compliance, providing the substrate for not only the base operating system but also an entire community of diverse interests to take part in the project."
+    },
+    "q9": {
+      "q": "If you’re not just repackaging RHEL, then what exactly are you doing?",
+      "a": "Our goal is to maintain Rocky Linux as a community-oriented distribution <i>by</i> the community, <i>for</i> the community. To do this, we are establishing the necessary organizational structures to ensure that Rocky Linux remains in the hands of the community. We want to make sure that it’s not possible for what happened to CentOS to happen to Rocky Linux."
+    },
+    "q10": {
+      "q": "How will you ensure that Rocky Linux truly remains a community enterprise operating system?",
+      "a": "First, we’ve taken steps to legally protect the Rocky Linux name. This means registering its trademarks and various associated properties to protect them from being controlled by another entity. We’ve achieved this by establishing them under the Rocky Enterprise Software Foundation (RESF). Next, we’re drafting a community charter that will define the organizational structure, objectives, values, and mission behind the legal entity that represents Rocky Linux. Critical in this charter is the establishment of principles that enable and protect the community: transparency, community involvement, open development, and independence. <strong> Rocky Linux will never be controlled, purchased, or otherwise influenced by a single entity or organization. </strong> Finally, we’re architecting and deploying the necessary infrastructure to further enable the community to contribute to Rocky Linux."
+    },
+    "q11": {
+      "q": "What infrastructure is necessary to enable the community?",
+      "a1": "We’ve established a number of teams to support the various efforts associated with developing Rocky Linux:",
+      "a2": "You can read more about this structure when it’s soon published. In order to enable collaboration across and within those teams, we needed to deploy our own chat infrastructure, forums, and website. Additionally, we’re also creating our build infrastructure, which will facilitate the development of the core operating system.",
+      "list": {
+        "community": "Community",
+        "core-inf": "Core Infrastructure",
+        "design": "Design",
+        "documentation": "Documentation",
+        "installer": "Installer",
+        "leadership": "Leadership",
+        "pkg-autob": "Package Auto-Builders",
+        "packaging": "Packaging",
+        "security": "Security",
+        "sigs": "Special Interest Groups (SIGs)",
+        "web": "Web"
+      }
+    },
+    "q12": {
+      "q": "Why does it take so much time to stand up a community and build infrastructure?",
+      "a": "It’s not terribly difficult to deploy a website, forums, or a build infrastructure in a reliable fashion. Our chat program for instance, which uses Mattermost, is distributed on a number of application servers behind a load balancer and was ready in just a couple of weeks. But it does require careful thought and planning to do it in a scalable and secure manner when you need to ensure vendor and platform agnosticity and long-term community involvement."
+    },
+    "q13": {
+      "q": "So what’s the short answer to all of this? What are some things you’re thinking about as you put Rocky Linux together?",
+      "a": "How do we carefully shepherd community trust? How do we ensure that anyone who wants to participate can not only do so immediately, but forever in the future as well? How do we engage and enable the community members who might not be as technical but want to contribute anyway? Solving for all of these challenges will take time, and we would love your help in doing so."
+    },
+    "q14": {
+      "q": "What if I have feedback or my question wasn’t answered here?",
+      "a": "Please email us: <a href=\"mailto:hello@rockylinux.org\">hello@rockylinux.org</a> and we’ll get back to you as soon as we can."
+    }
   }
 }

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -51,7 +51,10 @@
     "donate": "Donate",
     "store": "Store",
     "press": "Press",
-    "download": "Download"
+    "download": "Download",
+    "com_charter": "Community Charter",
+    "org_structure": "Organization Structure",
+    "privacy": "Privacy Policy"
   },
   "socials": {
     "forums": "Forums",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -1,78 +1,241 @@
 {
   "language": "en",
-  "copyright": {
-    "line1": "© 2021 Rocky Enterprise Software Foundation. All rights reserved.",
-    "line2": "Red Hat and CentOS are trademarks or registered trademarks of Red Hat, Inc. or its subsidiaries in the United States and other countries. We are not affiliated with, endorsed by or sponsored by Red Hat or the CentOS Project."
-  },
-  "errors": {
-    "404": {
-      "explanation": "The requested resource couldn't be located. Please try again.",
-      "title": "Page not found."
+
+  "global": {
+
+    "copyright": {
+      "line1": "© 2021 Rocky Enterprise Software Foundation. All rights reserved.",
+      "line2": "Red Hat and CentOS are trademarks or registered trademarks of Red Hat, Inc. or its subsidiaries in the United States and other countries. We are not affiliated with, endorsed by or sponsored by Red Hat or the CentOS Project."
+    },
+
+    "links": {
+      "close-menu": "Close menu",
+      "wiki": "Wiki",
+      "get-in-touch": "Get In Touch",
+      "get-involved": "Get Involved",
+      "go-home": "Go Home",
+      "join-the-discussion": "Join the Discussion",
+      "posts": "News",
+      "show-your-interest": "Show Your Interest",
+      "sponsors": "Sponsors",
+      "partners": "Partners",
+      "status": "Service Status",
+      "donate": "Donate",
+      "store": "Store",
+      "press": "Press",
+      "download": "Download",
+      "com_charter": "Community Charter",
+      "org_structure": "Organization Structure",
+      "privacy": "Privacy Policy",
+      "see-more": "See More",
+      "see-all": "See All",
+      "documentation": "Documentation",
+      "bug-report": "Report a bug"
+    },
+    "socials": {
+      "forums": "Forums",
+      "github": "Github",
+      "reddit": "Reddit",
+      "mattermost": "Mattermost",
+      "twitter": "Twitter"
     }
   },
-  "faq": {
-    "a": {
-      "come-in": "Rocky Linux aims to function as a downstream build as CentOS had done previously, building releases after they have been added by the upstream vendor, not before.",
-      "downstream-partner-direction": "The CentOS project recently announced a shift in strategy for CentOS. Whereas previously CentOS existed as a downstream build of its upstream vendor (it receives patches and updates after the upstream vendor does), it will be shifting to an upstream build (testing patches and updates before inclusion in the upstream vendor). Additionally, support for CentOS Linux 8 has been cut short, from May 31, 2029 to December 31, 2021."
+
+  "homepage": {
+    "landing": {
+      "p1": {
+        "heading": "Rocky Linux",
+        "content": "A community-driven effort to bring you enterprise-grade, production-ready Linux."
+      },
+      "p2": {
+        "heading": "What is the Rocky Linux project?",
+        "content": "Rocky Linux is a community enterprise operating system designed to be 100% bug-for-bug compatible with America's top enterprise Linux distribution now that its downstream partner has shifted direction. It is under intensive development by the community. Rocky Linux is led by Gregory Kurtzer, founder of the CentOS project. Release Candidate 1 is now available for testing. Contributors are asked to reach out using the communication options offered on this site."
+      }
     },
-    "q": {
-      "come-in": "So where does Rocky Linux come in?",
-      "downstream-partner-direction": "What do you mean, \"its downstream partner has shifted direction?\""
-    },
-    "title": "Frequently Asked Questions"
+    "faq": {
+      "title": "Frequently Asked Questions",
+      "a": {
+        "come-in": "Rocky Linux aims to function as a downstream build as CentOS had done previously, building releases after they have been added by the upstream vendor, not before.",
+        "downstream-partner-direction": "The CentOS project recently announced a shift in strategy for CentOS. Whereas previously CentOS existed as a downstream build of its upstream vendor (it receives patches and updates after the upstream vendor does), it will be shifting to an upstream build (testing patches and updates before inclusion in the upstream vendor). Additionally, support for CentOS Linux 8 has been cut short, from May 31, 2029 to December 31, 2021."
+      },
+      "q": {
+        "come-in": "So where does Rocky Linux come in?",
+        "downstream-partner-direction": "What do you mean, \"its downstream partner has shifted direction?\""
+      }
+    }
   },
-  "landing": {
+
+  "download": {
     "p1": {
-      "content": "A community-driven effort to bring you enterprise-grade, production-ready Linux.",
-      "heading": "Rocky Linux"
+      "heading": "Downloads",
+      "content": "Download the official release of Rocky Linux from one of our trusted mirrors."
+    },
+    "warning": "The release you can download here is a <i>Release Candidate</i> and should not be used in production. Please check our <a class=\"underline font-medium\" href=\"/faq/\">FAQ</a> for more information.",
+    "table": {
+      "architecture": "Architecture",
+      "iso": "ISOS",
+      "isos": {
+        "minimal": "Minimal",
+        "dvd": "DVD",
+        "boot": "Boot",
+        "checksum": "Checksum"
+      },
+      "packages": "Packages"
     },
     "p2": {
-      "content": "Rocky Linux is a community enterprise operating system designed to be 100% bug-for-bug compatible with America's top enterprise Linux distribution now that its downstream partner has shifted direction. It is under intensive development by the community. Rocky Linux is led by Gregory Kurtzer, founder of the CentOS project. Release Candidate 1 is now available for testing. Contributors are asked to reach out using the communication options offered on this site.",
-      "heading": "What is the Rocky Linux project?"
+      "content": "As you download and use Rocky Linux, the Rocky Enterprise Software Foundation invites you to <a class=\"text-green-600 dark:text-green-500 font-medium\" href=\"https://chat.rockylinux.org/\">be a part of the community as a contributor</a>. There are many ways to contribute to the project, from documentation, QA, and testing to coding changes for SIGs, providing mirroring or hosting, and helping other users."
     }
   },
+
   "lang": {
     "footer": {
       "choose-language": "Choose a language..."
     }
   },
-  "links": {
-    "close-menu": "Close menu",
-    "documentation": "Wiki",
-    "get-in-touch": "Get In Touch",
-    "get-involved": "Get Involved",
-    "go-home": "Go Home",
-    "join-the-discussion": "Join the Discussion",
-    "posts": "News",
-    "show-your-interest": "Show Your Interest",
-    "sponsors": "Sponsors",
-    "partners": "Partners",
-    "status": "Service Status",
-    "donate": "Donate",
-    "store": "Store",
-    "press": "Press",
-    "download": "Download",
-    "com_charter": "Community Charter",
-    "org_structure": "Organization Structure",
-    "privacy": "Privacy Policy"
+
+  "errors": {
+    "404": {
+      "title": "Page not found.",
+      "explanation": "The requested resource couldn't be located. Please try again."
+    }
   },
-  "socials": {
-    "forums": "Forums",
-    "github": "Github",
-    "reddit": "Reddit",
-    "mattermost": "Mattermost",
-    "twitter": "Twitter"
-  },
+
   "news": {
     "title": "News",
     "description": "Stay up-to-date on the latest from The Rocky Linux Project."
   },
+
   "press": {
     "title": "Press",
     "description": "See the latest about Rocky in the press."
   },
+
   "sponsors": {
     "title": "Sponsors",
-    "description": "We would like to thank our sponsors for their support thus far on the project."
+    "description": "We would like to thank our sponsors for their support thus far on the project.",
+    "tag": {
+      "fsponsor": "Founding Sponsor",
+      "psponsor": "Principal Sponsor"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "45drives": {
+        "name": "45Drives",
+        "description": "45Drives offers enterprise storage solutions built on powerful & robust open-source software that allows customers to benefit from the cost savings & flexibility of off-the-shelf hardware. Check them out for a fully supported data storage solution at the best cost per terabyte!"
+      },
+      "opendrives": {
+        "name": "OpenDrives",
+        "description": "OpenDrives is a global provider of enterprise-grade, hyper-scalable, network-attached-storage (NAS) solutions. We deliver the highest performing solutions for our customers - to match individual performance needs - for the most robust, complex and mission-critical projects and workflows, on-premises and into the cloud."
+      },
+      "montavista": {
+        "name": "MontaVista",
+        "description": "MontaVista Software is the leader in embedded commercial Linux, supporting MontaVista CGX, Yocto Project®, CentOS and Rocky Linux. MontaVista offers Open Source Software expertise, commercial-quality Linux distros, cost-effective maintenance and support for 10+ year life-cycles."
+      },
+      "aws": {
+        "name": "Amazon Web Services",
+        "description": "The RESF utilizes AWS to run much of the underlying infrastructure critical to the development and deployment of the services supporting Rocky Linux. From Koji builders for x86_64 and aarch64 running in EC2 to SRPM blob storage in S3, AWS is foundational to much of what we do."
+      }
+    }
+  },
+
+  "partners": {
+    "title": "Partners",
+    "description": "Partners of the RESF represent ongoing relationships of strategic importance to the Rocky Linux project. Through dedication of engineering expertise, infrastructure resources, or other means, their support is critical to our continued success and long term stability.",
+    "tag": {
+      "fpartner": "Founding Partner",
+      "ppartner": "Principal Partner"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "navercloud": {
+        "name": "NAVER Cloud",
+        "description": "NAVER Cloud Platform is a South Korean cloud service that started in 2017 under NAVER Cloud, a subsidiary of NAVER. It provides over 170 individual services in 2021 and holds various security certifications including CSA STAR GOLD, GDPR, and more. It also currently provides cloud services in 10 locations around the world."
+      },
+      "mattermost": {
+        "name": "Mattermost",
+        "description": "Mattermost is an open source messaging solution made for organizations with the highest security requirements. As big believers in the power of open source, Mattermost is thrilled to partner with RESF to help bring an enterprise-grade distribution of Linux to the tech community."
+      }
+    }
+  },
+
+  "faq": {
+    "heading": "Frequently Asked Questions",
+    "q1": {
+      "q": "Where can I download the release candidate?",
+      "a": "https://rockylinux.org/download"
+    },
+    "q2": {
+      "q": "What is a release candidate?",
+      "a": "A release candidate is a beta version of a product that has the potential to be stable.The intent of a release candidate is for the community to test and validate expected functionality of Rocky Linux and report any bugs if present."
+    },
+    "q3": {
+      "q": "Can I use the release candidate in production?",
+      "a": "Under no circumstance should you use a release candidate in a production environment. A release candidate is provided for testing and validation purposes only."
+    },
+    "q4": {
+      "q": "How can I help mirror the release candidate and future Rocky Linux releases?",
+      "a": "Please email <a href=\"mailto:mirrors@rockylinux.org\">mirrors@rockylinux.org</a> to express your interest."
+    },
+    "q5": {
+      "q": "I encountered a bug while testing the release candidate, what can I do?",
+      "a": "First, create an account using <a href=\"https://accounts.rockylinux.org/\"> Rocky Linux Account Services </a> , then head over to our <a href=\"https://bugs.rockylinux.org/\">Bugzilla server</a> to report any bugs."
+    },
+    "q6": {
+      "q": "How can I get involved with the Testing team?",
+      "a": "Please join the <a href=\"https://chat.rockylinux.org/rocky-linux/channels/testing\"> ~Testing </a> channel on our Mattermost server to get started. There’s also a testing topic on the forums for more durable conversation."
+    },
+    "q7": {
+      "q": "Where can I find the latest news about Rocky Linux?",
+      "a": "Stay tuned to our website, Twitter, LinkedIn, forums, and other platforms listed in our link directory for the latest announcements."
+    },
+    "q8": {
+      "q": "If Rocky Linux is just a respin of RHEL, what took so long for a release candidate?",
+      "a1": "If our only goal for Rocky Linux was to debrand and repackage RHEL, we would have been done much sooner. However, what we had to do differently is figure out how we could keep Rocky Linux in the hands of the community. Carefully devising this strategy ensures that Rocky Linux will never meet the same fate of CentOS.",
+      "a2": "The goal was not just to create a community managed RPM based distribution of Linux, but to ensure that it will remain freely available and always in the control of the community, much like Linux itself has. To do that required more than a build infrastructure; it required that we put in place the foundational structures that enable the community, ensuring that Rocky Linux is forever inclusive, free, and open. The infrastructure is built from the ground up by many collaborators and sponsoring organizations around composability and security compliance, providing the substrate for not only the base operating system but also an entire community of diverse interests to take part in the project."
+    },
+    "q9": {
+      "q": "If you’re not just repackaging RHEL, then what exactly are you doing?",
+      "a": "Our goal is to maintain Rocky Linux as a community-oriented distribution <i>by</i> the community, <i>for</i> the community. To do this, we are establishing the necessary organizational structures to ensure that Rocky Linux remains in the hands of the community. We want to make sure that it’s not possible for what happened to CentOS to happen to Rocky Linux."
+    },
+    "q10": {
+      "q": "How will you ensure that Rocky Linux truly remains a community enterprise operating system?",
+      "a": "First, we’ve taken steps to legally protect the Rocky Linux name. This means registering its trademarks and various associated properties to protect them from being controlled by another entity. We’ve achieved this by establishing them under the Rocky Enterprise Software Foundation (RESF). Next, we’re drafting a community charter that will define the organizational structure, objectives, values, and mission behind the legal entity that represents Rocky Linux. Critical in this charter is the establishment of principles that enable and protect the community: transparency, community involvement, open development, and independence. <strong> Rocky Linux will never be controlled, purchased, or otherwise influenced by a single entity or organization. </strong> Finally, we’re architecting and deploying the necessary infrastructure to further enable the community to contribute to Rocky Linux."
+    },
+    "q11": {
+      "q": "What infrastructure is necessary to enable the community?",
+      "a1": "We’ve established a number of teams to support the various efforts associated with developing Rocky Linux:",
+      "a2": "You can read more about this structure when it’s soon published. In order to enable collaboration across and within those teams, we needed to deploy our own chat infrastructure, forums, and website. Additionally, we’re also creating our build infrastructure, which will facilitate the development of the core operating system.",
+      "list": {
+        "community": "Community",
+        "core-inf": "Core Infrastructure",
+        "design": "Design",
+        "documentation": "Documentation",
+        "installer": "Installer",
+        "leadership": "Leadership",
+        "pkg-autob": "Package Auto-Builders",
+        "packaging": "Packaging",
+        "security": "Security",
+        "sigs": "Special Interest Groups (SIGs)",
+        "web": "Web"
+      }
+    },
+    "q12": {
+      "q": "Why does it take so much time to stand up a community and build infrastructure?",
+      "a": "It’s not terribly difficult to deploy a website, forums, or a build infrastructure in a reliable fashion. Our chat program for instance, which uses Mattermost, is distributed on a number of application servers behind a load balancer and was ready in just a couple of weeks. But it does require careful thought and planning to do it in a scalable and secure manner when you need to ensure vendor and platform agnosticity and long-term community involvement."
+    },
+    "q13": {
+      "q": "So what’s the short answer to all of this? What are some things you’re thinking about as you put Rocky Linux together?",
+      "a": "How do we carefully shepherd community trust? How do we ensure that anyone who wants to participate can not only do so immediately, but forever in the future as well? How do we engage and enable the community members who might not be as technical but want to contribute anyway? Solving for all of these challenges will take time, and we would love your help in doing so."
+    },
+    "q14": {
+      "q": "What if I have feedback or my question wasn’t answered here?",
+      "a": "Please email us: <a href=\"mailto:hello@rockylinux.org\">hello@rockylinux.org</a> and we’ll get back to you as soon as we can."
+    }
   }
 }

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -1,72 +1,241 @@
 {
   "language": "es",
-  "copyright": {
-    "line1": "© 2021 El proyecto Rocky Linux. Todos los derechos reservados.",
-    "line2": "CentOS es una marca registrada de Red Hat, Inc. El proyecto Rocky Linux no está afiliado ni respaldado por Red Hat, Inc."
-  },
-  "errors": {
-    "404": {
-      "explanation": "No se pudo localizar el recurso solicitado. Inténtalo de nuevo.",
-      "title": "Página no encontrada."
+
+  "global": {
+
+    "copyright": {
+      "line1": "© 2021 El proyecto Rocky Linux. Todos los derechos reservados.",
+      "line2": "CentOS es una marca registrada de Red Hat, Inc. El proyecto Rocky Linux no está afiliado ni respaldado por Red Hat, Inc."
+    },
+
+    "links": {
+      "close-menu": "Cerrar menu",
+      "wiki": "Wiki",
+      "get-in-touch": "Ponerse en contacto",
+      "get-involved": "Involucrarse",
+      "go-home": "Inicio",
+      "join-the-discussion": "Unirse a la discusión",
+      "posts": "News",
+      "show-your-interest": "Show Your Interest",
+      "sponsors": "Sponsors",
+      "partners": "Partners",
+      "status": "Service Status",
+      "donate": "Donate",
+      "store": "Store",
+      "press": "Press",
+      "download": "Download",
+      "com_charter": "Community Charter",
+      "org_structure": "Organization Structure",
+      "privacy": "Privacy Policy",
+      "see-more": "See More",
+      "see-all": "See All",
+      "documentation": "Documentación",
+      "bug-report": "Report a bug"
+    },
+    "socials": {
+      "forums": "Forums",
+      "github": "Github",
+      "reddit": "Reddit",
+      "mattermost": "Mattermost",
+      "twitter": "Twitter"
     }
   },
-  "faq": {
-    "a": {
-      "come-in": "Rocky Linux apunta a funcionar como una compilación descendente como lo había hecho CentOS anteriormente, construyendo versiones después de que hayan sido agregadas por el proveedor ascendente, no antes.",
-      "downstream-partner-direction": "El proyecto CentOS anunció recientemente un cambio en la estrategia de CentOS. Mientras que anteriormente CentOS existía como una compilación descendente de su proveedor ascendente (recibe parches y actualizaciones después de que lo hace el proveedor ascendente), se cambiará a una compilación ascendente (probando parches y actualizaciones antes de su inclusión en el proveedor ascendente). Además, el soporte para CentOS Linux 8 se ha interrumpido, cambiando el final del soporte del 31 de mayo de 2029 al 31 de diciembre de 2021."
+
+  "homepage": {
+    "landing": {
+      "p1": {
+        "heading": "Rocky Linux",
+        "content": "Un esfuerzo de la comunidad para obtener un sistema Linux de clase empresarial listo para producción."
+      },
+      "p2": {
+        "heading": "¿Que es el proyecto Rocky Linux?",
+        "content": "Rocky Linux es un sistema operativo empresarial comunitario diseñado para ser 100% compatible con la distribución de Linux empresarial más importante de Estados Unidos ahora que su socio intermedio ha cambiado de dirección. Está en desarrollo intensivo por parte de la comunidad. Rocky Linux está dirigido por Gregory Kurtzer, fundador del proyecto CentOS. No hay una fecha estimada para el lanzamiento. Se solicita a los colaboradores que se comuniquen con las opciones de comunicación que se ofrecen en este sitio."
+      }
     },
-    "q": {
-      "come-in": "Entonces, ¿dónde entra Rocky Linux?",
-      "downstream-partner-direction": "¿Qué significa que, \"su socio anterior haya cambiado de dirección?\""
-    },
-    "title": "Preguntas frecuentes"
+    "faq": {
+      "title": "Preguntas frecuentes",
+      "a": {
+        "come-in": "Rocky Linux apunta a funcionar como una compilación descendente como lo había hecho CentOS anteriormente, construyendo versiones después de que hayan sido agregadas por el proveedor ascendente, no antes.",
+        "downstream-partner-direction": "El proyecto CentOS anunció recientemente un cambio en la estrategia de CentOS. Mientras que anteriormente CentOS existía como una compilación descendente de su proveedor ascendente (recibe parches y actualizaciones después de que lo hace el proveedor ascendente), se cambiará a una compilación ascendente (probando parches y actualizaciones antes de su inclusión en el proveedor ascendente). Además, el soporte para CentOS Linux 8 se ha interrumpido, cambiando el final del soporte del 31 de mayo de 2029 al 31 de diciembre de 2021."
+      },
+      "q": {
+        "come-in": "Entonces, ¿dónde entra Rocky Linux?",
+        "downstream-partner-direction": "¿Qué significa que, \"su socio anterior haya cambiado de dirección?\""
+      }
+    }
   },
-  "landing": {
+
+  "download": {
     "p1": {
-      "content": "Un esfuerzo de la comunidad para obtener un sistema Linux de clase empresarial listo para producción.",
-      "heading": "Rocky Linux"
+      "heading": "Downloads",
+      "content": "Download the official release of Rocky Linux from one of our trusted mirrors."
+    },
+    "warning": "The release you can download here is a <i>Release Candidate</i> and should not be used in production. Please check our <a class=\"underline font-medium\" href=\"/faq/\">FAQ</a> for more information.",
+    "table": {
+      "architecture": "Architecture",
+      "iso": "ISOS",
+      "isos": {
+        "minimal": "Minimal",
+        "dvd": "DVD",
+        "boot": "Boot",
+        "checksum": "Checksum"
+      },
+      "packages": "Packages"
     },
     "p2": {
-      "content": "Rocky Linux es un sistema operativo empresarial comunitario diseñado para ser 100% compatible con la distribución de Linux empresarial más importante de Estados Unidos ahora que su socio intermedio ha cambiado de dirección. Está en desarrollo intensivo por parte de la comunidad. Rocky Linux está dirigido por Gregory Kurtzer, fundador del proyecto CentOS. No hay una fecha estimada para el lanzamiento. Se solicita a los colaboradores que se comuniquen con las opciones de comunicación que se ofrecen en este sitio.",
-      "heading": "¿Que es el proyecto Rocky Linux?"
+      "content": "As you download and use Rocky Linux, the Rocky Enterprise Software Foundation invites you to <a class=\"text-green-600 dark:text-green-500 font-medium\" href=\"https://chat.rockylinux.org/\">be a part of the community as a contributor</a>. There are many ways to contribute to the project, from documentation, QA, and testing to coding changes for SIGs, providing mirroring or hosting, and helping other users."
     }
   },
+
   "lang": {
     "footer": {
-      "choose-language": "Elegir idioma..."
+      "choose-language": "Choose a language..."
     }
   },
-  "links": {
-    "close-menu": "Cerrar menu",
-    "documentation": "Documentación",
-    "get-in-touch": "Ponerse en contacto",
-    "get-involved": "Involucrarse",
-    "go-home": "Inicio",
-    "join-the-discussion": "Unirse a la discusión",
-    "posts": "News",
-    "show-your-interest": "Show Your Interest",
-    "sponsors": "Sponsors",
-    "donate": "Donate",
-    "store": "Store",
-    "press": "Press"
+
+  "errors": {
+    "404": {
+      "title": "Página no encontrada.",
+      "explanation": "No se pudo localizar el recurso solicitado. Inténtalo de nuevo."
+    }
   },
-  "socials": {
-    "forums": "Forums",
-    "github": "Github",
-    "reddit": "Reddit",
-    "mattermost": "Mattermost",
-    "twitter": "Twitter"
-  },
+
   "news": {
     "title": "News",
     "description": "Stay up-to-date on the latest from The Rocky Linux Project."
   },
+
   "press": {
     "title": "Press",
     "description": "See the latest about Rocky in the press."
   },
+
   "sponsors": {
     "title": "Sponsors",
-    "description": "We would like to thank our sponsors for their support thus far on the project."
+    "description": "We would like to thank our sponsors for their support thus far on the project.",
+    "tag": {
+      "fsponsor": "Founding Sponsor",
+      "psponsor": "Principal Sponsor"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "45drives": {
+        "name": "45Drives",
+        "description": "45Drives offers enterprise storage solutions built on powerful & robust open-source software that allows customers to benefit from the cost savings & flexibility of off-the-shelf hardware. Check them out for a fully supported data storage solution at the best cost per terabyte!"
+      },
+      "opendrives": {
+        "name": "OpenDrives",
+        "description": "OpenDrives is a global provider of enterprise-grade, hyper-scalable, network-attached-storage (NAS) solutions. We deliver the highest performing solutions for our customers - to match individual performance needs - for the most robust, complex and mission-critical projects and workflows, on-premises and into the cloud."
+      },
+      "montavista": {
+        "name": "MontaVista",
+        "description": "MontaVista Software is the leader in embedded commercial Linux, supporting MontaVista CGX, Yocto Project®, CentOS and Rocky Linux. MontaVista offers Open Source Software expertise, commercial-quality Linux distros, cost-effective maintenance and support for 10+ year life-cycles."
+      },
+      "aws": {
+        "name": "Amazon Web Services",
+        "description": "The RESF utilizes AWS to run much of the underlying infrastructure critical to the development and deployment of the services supporting Rocky Linux. From Koji builders for x86_64 and aarch64 running in EC2 to SRPM blob storage in S3, AWS is foundational to much of what we do."
+      }
+    }
+  },
+
+  "partners": {
+    "title": "Partners",
+    "description": "Partners of the RESF represent ongoing relationships of strategic importance to the Rocky Linux project. Through dedication of engineering expertise, infrastructure resources, or other means, their support is critical to our continued success and long term stability.",
+    "tag": {
+      "fpartner": "Founding Partner",
+      "ppartner": "Principal Partner"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "navercloud": {
+        "name": "NAVER Cloud",
+        "description": "NAVER Cloud Platform is a South Korean cloud service that started in 2017 under NAVER Cloud, a subsidiary of NAVER. It provides over 170 individual services in 2021 and holds various security certifications including CSA STAR GOLD, GDPR, and more. It also currently provides cloud services in 10 locations around the world."
+      },
+      "mattermost": {
+        "name": "Mattermost",
+        "description": "Mattermost is an open source messaging solution made for organizations with the highest security requirements. As big believers in the power of open source, Mattermost is thrilled to partner with RESF to help bring an enterprise-grade distribution of Linux to the tech community."
+      }
+    }
+  },
+
+  "faq": {
+    "heading": "Frequently Asked Questions",
+    "q1": {
+      "q": "Where can I download the release candidate?",
+      "a": "https://rockylinux.org/download"
+    },
+    "q2": {
+      "q": "What is a release candidate?",
+      "a": "A release candidate is a beta version of a product that has the potential to be stable.The intent of a release candidate is for the community to test and validate expected functionality of Rocky Linux and report any bugs if present."
+    },
+    "q3": {
+      "q": "Can I use the release candidate in production?",
+      "a": "Under no circumstance should you use a release candidate in a production environment. A release candidate is provided for testing and validation purposes only."
+    },
+    "q4": {
+      "q": "How can I help mirror the release candidate and future Rocky Linux releases?",
+      "a": "Please email <a href=\"mailto:mirrors@rockylinux.org\">mirrors@rockylinux.org</a> to express your interest."
+    },
+    "q5": {
+      "q": "I encountered a bug while testing the release candidate, what can I do?",
+      "a": "First, create an account using <a href=\"https://accounts.rockylinux.org/\"> Rocky Linux Account Services </a> , then head over to our <a href=\"https://bugs.rockylinux.org/\">Bugzilla server</a> to report any bugs."
+    },
+    "q6": {
+      "q": "How can I get involved with the Testing team?",
+      "a": "Please join the <a href=\"https://chat.rockylinux.org/rocky-linux/channels/testing\"> ~Testing </a> channel on our Mattermost server to get started. There’s also a testing topic on the forums for more durable conversation."
+    },
+    "q7": {
+      "q": "Where can I find the latest news about Rocky Linux?",
+      "a": "Stay tuned to our website, Twitter, LinkedIn, forums, and other platforms listed in our link directory for the latest announcements."
+    },
+    "q8": {
+      "q": "If Rocky Linux is just a respin of RHEL, what took so long for a release candidate?",
+      "a1": "If our only goal for Rocky Linux was to debrand and repackage RHEL, we would have been done much sooner. However, what we had to do differently is figure out how we could keep Rocky Linux in the hands of the community. Carefully devising this strategy ensures that Rocky Linux will never meet the same fate of CentOS.",
+      "a2": "The goal was not just to create a community managed RPM based distribution of Linux, but to ensure that it will remain freely available and always in the control of the community, much like Linux itself has. To do that required more than a build infrastructure; it required that we put in place the foundational structures that enable the community, ensuring that Rocky Linux is forever inclusive, free, and open. The infrastructure is built from the ground up by many collaborators and sponsoring organizations around composability and security compliance, providing the substrate for not only the base operating system but also an entire community of diverse interests to take part in the project."
+    },
+    "q9": {
+      "q": "If you’re not just repackaging RHEL, then what exactly are you doing?",
+      "a": "Our goal is to maintain Rocky Linux as a community-oriented distribution <i>by</i> the community, <i>for</i> the community. To do this, we are establishing the necessary organizational structures to ensure that Rocky Linux remains in the hands of the community. We want to make sure that it’s not possible for what happened to CentOS to happen to Rocky Linux."
+    },
+    "q10": {
+      "q": "How will you ensure that Rocky Linux truly remains a community enterprise operating system?",
+      "a": "First, we’ve taken steps to legally protect the Rocky Linux name. This means registering its trademarks and various associated properties to protect them from being controlled by another entity. We’ve achieved this by establishing them under the Rocky Enterprise Software Foundation (RESF). Next, we’re drafting a community charter that will define the organizational structure, objectives, values, and mission behind the legal entity that represents Rocky Linux. Critical in this charter is the establishment of principles that enable and protect the community: transparency, community involvement, open development, and independence. <strong> Rocky Linux will never be controlled, purchased, or otherwise influenced by a single entity or organization. </strong> Finally, we’re architecting and deploying the necessary infrastructure to further enable the community to contribute to Rocky Linux."
+    },
+    "q11": {
+      "q": "What infrastructure is necessary to enable the community?",
+      "a1": "We’ve established a number of teams to support the various efforts associated with developing Rocky Linux:",
+      "a2": "You can read more about this structure when it’s soon published. In order to enable collaboration across and within those teams, we needed to deploy our own chat infrastructure, forums, and website. Additionally, we’re also creating our build infrastructure, which will facilitate the development of the core operating system.",
+      "list": {
+        "community": "Community",
+        "core-inf": "Core Infrastructure",
+        "design": "Design",
+        "documentation": "Documentation",
+        "installer": "Installer",
+        "leadership": "Leadership",
+        "pkg-autob": "Package Auto-Builders",
+        "packaging": "Packaging",
+        "security": "Security",
+        "sigs": "Special Interest Groups (SIGs)",
+        "web": "Web"
+      }
+    },
+    "q12": {
+      "q": "Why does it take so much time to stand up a community and build infrastructure?",
+      "a": "It’s not terribly difficult to deploy a website, forums, or a build infrastructure in a reliable fashion. Our chat program for instance, which uses Mattermost, is distributed on a number of application servers behind a load balancer and was ready in just a couple of weeks. But it does require careful thought and planning to do it in a scalable and secure manner when you need to ensure vendor and platform agnosticity and long-term community involvement."
+    },
+    "q13": {
+      "q": "So what’s the short answer to all of this? What are some things you’re thinking about as you put Rocky Linux together?",
+      "a": "How do we carefully shepherd community trust? How do we ensure that anyone who wants to participate can not only do so immediately, but forever in the future as well? How do we engage and enable the community members who might not be as technical but want to contribute anyway? Solving for all of these challenges will take time, and we would love your help in doing so."
+    },
+    "q14": {
+      "q": "What if I have feedback or my question wasn’t answered here?",
+      "a": "Please email us: <a href=\"mailto:hello@rockylinux.org\">hello@rockylinux.org</a> and we’ll get back to you as soon as we can."
+    }
   }
 }

--- a/src/i18n/locales/fa/translation.json
+++ b/src/i18n/locales/fa/translation.json
@@ -1,72 +1,241 @@
 {
   "language": "fa",
-  "copyright": {
-    "line1": "© 2021 پروژهٔ Rocky Linux. تمام حقوق محفوظ است.",
-    "line2": "نام CentOS یک نام تجاری ثبت شده برای کمپانی RedHat است. پروژهٔ Rocky Linux وابسته یا تحت تایید کمپانی RedHat نیست."
-  },
-  "errors": {
-    "404": {
-      "explanation": "قادر به پیدا کردن محتوای درخواستی نیستیم. لطفا دوباره تلاش کنید.",
-      "title": "صفحهٔ موردنظر یافت نشد."
+
+  "global": {
+
+    "copyright": {
+      "line1": "© 2021 پروژهٔ Rocky Linux. تمام حقوق محفوظ است.",
+      "line2": "نام CentOS یک نام تجاری ثبت شده برای کمپانی RedHat است. پروژهٔ Rocky Linux وابسته یا تحت تایید کمپانی RedHat نیست."
+    },
+
+    "links": {
+      "close-menu": "بستن فهرست",
+      "wiki": "Wiki",
+      "get-in-touch": "ارتباط با ما",
+      "get-involved": "مشارکت کنید",
+      "go-home": "رفتن به خانه",
+      "join-the-discussion": "به بحث بپیوندید",
+      "posts": "News",
+      "show-your-interest": "Show Your Interest",
+      "sponsors": "Sponsors",
+      "partners": "Partners",
+      "status": "Service Status",
+      "donate": "Donate",
+      "store": "Store",
+      "press": "Press",
+      "download": "Download",
+      "com_charter": "Community Charter",
+      "org_structure": "Organization Structure",
+      "privacy": "Privacy Policy",
+      "see-more": "See More",
+      "see-all": "See All",
+      "documentation": "مستندات",
+      "bug-report": "Report a bug"
+    },
+    "socials": {
+      "forums": "Forums",
+      "github": "Github",
+      "reddit": "Reddit",
+      "mattermost": "Mattermost",
+      "twitter": "Twitter"
     }
   },
-  "faq": {
-    "a": {
-      "come-in": "هدف Rocky Linux این است که یک توزیع پایین‌دست مانند وضعیت سابق CentOS باشد. تغییرات را پس از این که در توزیع بالادست عرضه شدند عرضه کند، نه قبل از آن.",
-      "downstream-partner-direction": "استراتژی پروژهٔ CentOS اخیراً دچار دگرگونی شده است. پیش‌تر CentOS یک توزیع پایین‌دست برای توزیع بالادست خود بود (آپدیت‌ها و وصله‌ها را پس از توزیع بالادست دریافت می‌کرد). در آینده، CentOS به یک توزیع بالادست تبدیل خواهد شد (آپدیت‌ها و وصله‌های آزمایشی را زودتر دریافت خواهد کرد). همچنین، تاریخ پایان مدت پشتیبانی CentOS Linux 8 از ۳۱ می ۲۰۲۹ به ۳۱ دسامبر ۲۰۲۱ منتقل شده است."
+
+  "homepage": {
+    "landing": {
+      "p1": {
+        "heading": "Rocky Linux",
+        "content": "یک تلاش جمعی برای ایجاد لینوکس سازمانی و آمادهٔ بهره‌برداری برای شما"
+      },
+      "p2": {
+        "heading": "پروژهٔ Rocky Linux  چیست؟",
+        "content": "Rocky Linux یک سیستم‌عامل سازمانی آزاد با سازگاری کامل با توزیع لینوکس سازمانی پیشرو در قارهٔ آمریکا - که توزیع پایین‌دست آن در حال تغییر جهت است - است. این پروژه تحت توسعهٔ متمرکز توسط جامعه است. Rocky Linux توسط گرگوری کورتز، بنیان گذار پروژهٔ CentOS هدایت می‌شود. تخمینی از زمان عرضهٔ پروژه وجود ندارد. از مشارکت‌کنندگان دعوت می‌شود تا به واسطهٔ راه‌های ارتباطی ارائه‌شده در این سایت، با ما در ارتباط باشند."
+      }
     },
-    "q": {
-      "come-in": "هدف از ساخت Rocky Linux چیست؟",
-      "downstream-partner-direction": "منظور از «توزیع‌ پایین‌دست آن تغییر جهت داده است» چیست؟"
-    },
-    "title": "پرسش‌های پرتکرار"
+    "faq": {
+      "title": "پرسش‌های پرتکرار",
+      "a": {
+        "come-in": "هدف Rocky Linux این است که یک توزیع پایین‌دست مانند وضعیت سابق CentOS باشد. تغییرات را پس از این که در توزیع بالادست عرضه شدند عرضه کند، نه قبل از آن.",
+        "downstream-partner-direction": "استراتژی پروژهٔ CentOS اخیراً دچار دگرگونی شده است. پیش‌تر CentOS یک توزیع پایین‌دست برای توزیع بالادست خود بود (آپدیت‌ها و وصله‌ها را پس از توزیع بالادست دریافت می‌کرد). در آینده، CentOS به یک توزیع بالادست تبدیل خواهد شد (آپدیت‌ها و وصله‌های آزمایشی را زودتر دریافت خواهد کرد). همچنین، تاریخ پایان مدت پشتیبانی CentOS Linux 8 از ۳۱ می ۲۰۲۹ به ۳۱ دسامبر ۲۰۲۱ منتقل شده است."
+      },
+      "q": {
+        "come-in": "هدف از ساخت Rocky Linux چیست؟",
+        "downstream-partner-direction": "منظور از «توزیع‌ پایین‌دست آن تغییر جهت داده است» چیست؟"
+      }
+    }
   },
-  "landing": {
+
+  "download": {
     "p1": {
-      "content": "یک تلاش جمعی برای ایجاد لینوکس سازمانی و آمادهٔ بهره‌برداری برای شما",
-      "heading": "Rocky Linux"
+      "heading": "Downloads",
+      "content": "Download the official release of Rocky Linux from one of our trusted mirrors."
+    },
+    "warning": "The release you can download here is a <i>Release Candidate</i> and should not be used in production. Please check our <a class=\"underline font-medium\" href=\"/faq/\">FAQ</a> for more information.",
+    "table": {
+      "architecture": "Architecture",
+      "iso": "ISOS",
+      "isos": {
+        "minimal": "Minimal",
+        "dvd": "DVD",
+        "boot": "Boot",
+        "checksum": "Checksum"
+      },
+      "packages": "Packages"
     },
     "p2": {
-      "content": "Rocky Linux یک سیستم‌عامل سازمانی آزاد با سازگاری کامل با توزیع لینوکس سازمانی پیشرو در قارهٔ آمریکا - که توزیع پایین‌دست آن در حال تغییر جهت است - است. این پروژه تحت توسعهٔ متمرکز توسط جامعه است. Rocky Linux توسط گرگوری کورتز، بنیان گذار پروژهٔ CentOS هدایت می‌شود. تخمینی از زمان عرضهٔ پروژه وجود ندارد. از مشارکت‌کنندگان دعوت می‌شود تا به واسطهٔ راه‌های ارتباطی ارائه‌شده در این سایت، با ما در ارتباط باشند.",
-      "heading": "پروژهٔ Rocky Linux  چیست؟"
+      "content": "As you download and use Rocky Linux, the Rocky Enterprise Software Foundation invites you to <a class=\"text-green-600 dark:text-green-500 font-medium\" href=\"https://chat.rockylinux.org/\">be a part of the community as a contributor</a>. There are many ways to contribute to the project, from documentation, QA, and testing to coding changes for SIGs, providing mirroring or hosting, and helping other users."
     }
   },
+
   "lang": {
     "footer": {
       "choose-language": "Choose a language..."
     }
   },
-  "links": {
-    "close-menu": "بستن فهرست",
-    "documentation": "مستندات",
-    "get-in-touch": "ارتباط با ما",
-    "get-involved": "مشارکت کنید",
-    "go-home": "رفتن به خانه",
-    "join-the-discussion": "به بحث بپیوندید",
-    "posts": "News",
-    "show-your-interest": "Show Your Interest",
-    "sponsors": "Sponsors",
-    "donate": "Donate",
-    "store": "Store",
-    "press": "Press"
+
+  "errors": {
+    "404": {
+      "title": "صفحهٔ موردنظر یافت نشد.",
+      "explanation": "قادر به پیدا کردن محتوای درخواستی نیستیم. لطفا دوباره تلاش کنید."
+    }
   },
-  "socials": {
-    "forums": "Forums",
-    "github": "Github",
-    "reddit": "Reddit",
-    "mattermost": "Mattermost",
-    "twitter": "Twitter"
-  },
+
   "news": {
     "title": "News",
     "description": "Stay up-to-date on the latest from The Rocky Linux Project."
   },
+
   "press": {
     "title": "Press",
     "description": "See the latest about Rocky in the press."
   },
+
   "sponsors": {
     "title": "Sponsors",
-    "description": "We would like to thank our sponsors for their support thus far on the project."
+    "description": "We would like to thank our sponsors for their support thus far on the project.",
+    "tag": {
+      "fsponsor": "Founding Sponsor",
+      "psponsor": "Principal Sponsor"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "45drives": {
+        "name": "45Drives",
+        "description": "45Drives offers enterprise storage solutions built on powerful & robust open-source software that allows customers to benefit from the cost savings & flexibility of off-the-shelf hardware. Check them out for a fully supported data storage solution at the best cost per terabyte!"
+      },
+      "opendrives": {
+        "name": "OpenDrives",
+        "description": "OpenDrives is a global provider of enterprise-grade, hyper-scalable, network-attached-storage (NAS) solutions. We deliver the highest performing solutions for our customers - to match individual performance needs - for the most robust, complex and mission-critical projects and workflows, on-premises and into the cloud."
+      },
+      "montavista": {
+        "name": "MontaVista",
+        "description": "MontaVista Software is the leader in embedded commercial Linux, supporting MontaVista CGX, Yocto Project®, CentOS and Rocky Linux. MontaVista offers Open Source Software expertise, commercial-quality Linux distros, cost-effective maintenance and support for 10+ year life-cycles."
+      },
+      "aws": {
+        "name": "Amazon Web Services",
+        "description": "The RESF utilizes AWS to run much of the underlying infrastructure critical to the development and deployment of the services supporting Rocky Linux. From Koji builders for x86_64 and aarch64 running in EC2 to SRPM blob storage in S3, AWS is foundational to much of what we do."
+      }
+    }
+  },
+
+  "partners": {
+    "title": "Partners",
+    "description": "Partners of the RESF represent ongoing relationships of strategic importance to the Rocky Linux project. Through dedication of engineering expertise, infrastructure resources, or other means, their support is critical to our continued success and long term stability.",
+    "tag": {
+      "fpartner": "Founding Partner",
+      "ppartner": "Principal Partner"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "navercloud": {
+        "name": "NAVER Cloud",
+        "description": "NAVER Cloud Platform is a South Korean cloud service that started in 2017 under NAVER Cloud, a subsidiary of NAVER. It provides over 170 individual services in 2021 and holds various security certifications including CSA STAR GOLD, GDPR, and more. It also currently provides cloud services in 10 locations around the world."
+      },
+      "mattermost": {
+        "name": "Mattermost",
+        "description": "Mattermost is an open source messaging solution made for organizations with the highest security requirements. As big believers in the power of open source, Mattermost is thrilled to partner with RESF to help bring an enterprise-grade distribution of Linux to the tech community."
+      }
+    }
+  },
+
+  "faq": {
+    "heading": "Frequently Asked Questions",
+    "q1": {
+      "q": "Where can I download the release candidate?",
+      "a": "https://rockylinux.org/download"
+    },
+    "q2": {
+      "q": "What is a release candidate?",
+      "a": "A release candidate is a beta version of a product that has the potential to be stable.The intent of a release candidate is for the community to test and validate expected functionality of Rocky Linux and report any bugs if present."
+    },
+    "q3": {
+      "q": "Can I use the release candidate in production?",
+      "a": "Under no circumstance should you use a release candidate in a production environment. A release candidate is provided for testing and validation purposes only."
+    },
+    "q4": {
+      "q": "How can I help mirror the release candidate and future Rocky Linux releases?",
+      "a": "Please email <a href=\"mailto:mirrors@rockylinux.org\">mirrors@rockylinux.org</a> to express your interest."
+    },
+    "q5": {
+      "q": "I encountered a bug while testing the release candidate, what can I do?",
+      "a": "First, create an account using <a href=\"https://accounts.rockylinux.org/\"> Rocky Linux Account Services </a> , then head over to our <a href=\"https://bugs.rockylinux.org/\">Bugzilla server</a> to report any bugs."
+    },
+    "q6": {
+      "q": "How can I get involved with the Testing team?",
+      "a": "Please join the <a href=\"https://chat.rockylinux.org/rocky-linux/channels/testing\"> ~Testing </a> channel on our Mattermost server to get started. There’s also a testing topic on the forums for more durable conversation."
+    },
+    "q7": {
+      "q": "Where can I find the latest news about Rocky Linux?",
+      "a": "Stay tuned to our website, Twitter, LinkedIn, forums, and other platforms listed in our link directory for the latest announcements."
+    },
+    "q8": {
+      "q": "If Rocky Linux is just a respin of RHEL, what took so long for a release candidate?",
+      "a1": "If our only goal for Rocky Linux was to debrand and repackage RHEL, we would have been done much sooner. However, what we had to do differently is figure out how we could keep Rocky Linux in the hands of the community. Carefully devising this strategy ensures that Rocky Linux will never meet the same fate of CentOS.",
+      "a2": "The goal was not just to create a community managed RPM based distribution of Linux, but to ensure that it will remain freely available and always in the control of the community, much like Linux itself has. To do that required more than a build infrastructure; it required that we put in place the foundational structures that enable the community, ensuring that Rocky Linux is forever inclusive, free, and open. The infrastructure is built from the ground up by many collaborators and sponsoring organizations around composability and security compliance, providing the substrate for not only the base operating system but also an entire community of diverse interests to take part in the project."
+    },
+    "q9": {
+      "q": "If you’re not just repackaging RHEL, then what exactly are you doing?",
+      "a": "Our goal is to maintain Rocky Linux as a community-oriented distribution <i>by</i> the community, <i>for</i> the community. To do this, we are establishing the necessary organizational structures to ensure that Rocky Linux remains in the hands of the community. We want to make sure that it’s not possible for what happened to CentOS to happen to Rocky Linux."
+    },
+    "q10": {
+      "q": "How will you ensure that Rocky Linux truly remains a community enterprise operating system?",
+      "a": "First, we’ve taken steps to legally protect the Rocky Linux name. This means registering its trademarks and various associated properties to protect them from being controlled by another entity. We’ve achieved this by establishing them under the Rocky Enterprise Software Foundation (RESF). Next, we’re drafting a community charter that will define the organizational structure, objectives, values, and mission behind the legal entity that represents Rocky Linux. Critical in this charter is the establishment of principles that enable and protect the community: transparency, community involvement, open development, and independence. <strong> Rocky Linux will never be controlled, purchased, or otherwise influenced by a single entity or organization. </strong> Finally, we’re architecting and deploying the necessary infrastructure to further enable the community to contribute to Rocky Linux."
+    },
+    "q11": {
+      "q": "What infrastructure is necessary to enable the community?",
+      "a1": "We’ve established a number of teams to support the various efforts associated with developing Rocky Linux:",
+      "a2": "You can read more about this structure when it’s soon published. In order to enable collaboration across and within those teams, we needed to deploy our own chat infrastructure, forums, and website. Additionally, we’re also creating our build infrastructure, which will facilitate the development of the core operating system.",
+      "list": {
+        "community": "Community",
+        "core-inf": "Core Infrastructure",
+        "design": "Design",
+        "documentation": "Documentation",
+        "installer": "Installer",
+        "leadership": "Leadership",
+        "pkg-autob": "Package Auto-Builders",
+        "packaging": "Packaging",
+        "security": "Security",
+        "sigs": "Special Interest Groups (SIGs)",
+        "web": "Web"
+      }
+    },
+    "q12": {
+      "q": "Why does it take so much time to stand up a community and build infrastructure?",
+      "a": "It’s not terribly difficult to deploy a website, forums, or a build infrastructure in a reliable fashion. Our chat program for instance, which uses Mattermost, is distributed on a number of application servers behind a load balancer and was ready in just a couple of weeks. But it does require careful thought and planning to do it in a scalable and secure manner when you need to ensure vendor and platform agnosticity and long-term community involvement."
+    },
+    "q13": {
+      "q": "So what’s the short answer to all of this? What are some things you’re thinking about as you put Rocky Linux together?",
+      "a": "How do we carefully shepherd community trust? How do we ensure that anyone who wants to participate can not only do so immediately, but forever in the future as well? How do we engage and enable the community members who might not be as technical but want to contribute anyway? Solving for all of these challenges will take time, and we would love your help in doing so."
+    },
+    "q14": {
+      "q": "What if I have feedback or my question wasn’t answered here?",
+      "a": "Please email us: <a href=\"mailto:hello@rockylinux.org\">hello@rockylinux.org</a> and we’ll get back to you as soon as we can."
+    }
   }
 }

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -1,78 +1,241 @@
 {
   "language": "fr",
-  "copyright": {
-    "line1": "© 2021 The Rocky Linux Project. Tous droits réservés.",
-    "line2": "CentOS est une marque déposée de Red Hat, Inc. Le projet Rocky Linux n'est pas affilié à Red Hat, Inc. et n'est pas approuvé par cette société. "
-  },
-  "errors": {
-    "404": {
-      "explanation": "La ressource demandée n'a pas pu être localisée. Veuillez réessayer.",
-      "title": "Page non trouvée."
+
+  "global": {
+
+    "copyright": {
+      "line1": "© 2021 The Rocky Linux Project. Tous droits réservés.",
+      "line2": "CentOS est une marque déposée de Red Hat, Inc. Le projet Rocky Linux n'est pas affilié à Red Hat, Inc. et n'est pas approuvé par cette société. "
+    },
+
+    "links": {
+      "close-menu": "Fermer le menu",
+      "documentation": "Documentation",
+      "get-in-touch": "Contactez-nous",
+      "get-involved": "S'engager",
+      "go-home": "Retour à l'accueil",
+      "join-the-discussion": "Participez aux discussions",
+      "posts": "Nouveautés",
+      "show-your-interest": "Faites part de votre intérêt",
+      "sponsors": "Sponsors",
+      "partners": "Partenaires",
+      "status": "Status des services",
+      "donate": "Don",
+      "store": "Boutique",
+      "press": "Presse",
+      "download": "Télécharger",
+      "com_charter": "Charte communautaire",
+      "org_structure": "Structure de l'Organisation",
+      "privacy": "Politique de confidentialité",
+      "see-more": "See More",
+      "see-all": "See All",
+      "documentation": "Documentation",
+      "bug-report": "Report a bug"
+    },
+    "socials": {
+      "forums": "Forums",
+      "github": "Github",
+      "reddit": "Reddit",
+      "mattermost": "Mattermost",
+      "twitter": "Twitter"
     }
   },
-  "faq": {
-    "a": {
-      "come-in": "Rocky Linux vise à fonctionner comme une construction en aval comme CentOS l'avait fait auparavant, en construisant des versions après qu'elles aient été ajoutées par le fournisseur en amont, et non avant.",
-      "downstream-partner-direction": "Le projet CentOS a récemment annoncé un changement de stratégie. Alors que CentOS existait auparavant en tant que version en aval de son fournisseur en amont (il reçoit les correctifs et les mises à jour après que le fournisseur en amont le fasse), il passera à une version en amont (test des correctifs et des mises à jour avant leur inclusion dans le fournisseur en amont). De plus, la prise en charge de CentOS Linux 8 a été interrompue, du 31 mai 2029 au 31 décembre 2021."
+
+  "homepage": {
+    "landing": {
+      "p1": {
+        "heading": "Rocky Linux",
+        "content": " Un effort communautaire pour vous apporter une distribution Linux de qualité professionnelle, prêt pour la production."
+      },
+      "p2": {
+        "heading": "Qu'est-ce que le projet Rocky Linux ?",
+        "content": "Rocky Linux est un système d'exploitation d'entreprise communautaire conçu pour être 100% compatible bogue pour bogue avec la principale distribution d'entreprise Linux américaine, maintenant que son partenaire en aval a changé de direction. Elle est en cours de développement intensif par la communauté. Rocky Linux est dirigé par Gregory Kurtzer, fondateur du projet CentOS. Il n'y a pas d'ETA pour une version. Les contributeurs sont invités à nous contacter en utilisant les options de communication proposées sur ce site."
+      }
     },
-    "q": {
-      "come-in": "Quel est l'intérêt de Rocky Linux ?",
-      "downstream-partner-direction": "Que voulez-vous dire par \"son partenaire en aval a changé de direction\" ?"
-    },
-    "title": "Questions fréquemment posées"
+    "faq": {
+      "title": "Questions fréquemment posées",
+      "a": {
+        "come-in": "Rocky Linux vise à fonctionner comme une construction en aval comme CentOS l'avait fait auparavant, en construisant des versions après qu'elles aient été ajoutées par le fournisseur en amont, et non avant.",
+        "downstream-partner-direction": "Le projet CentOS a récemment annoncé un changement de stratégie. Alors que CentOS existait auparavant en tant que version en aval de son fournisseur en amont (il reçoit les correctifs et les mises à jour après que le fournisseur en amont le fasse), il passera à une version en amont (test des correctifs et des mises à jour avant leur inclusion dans le fournisseur en amont). De plus, la prise en charge de CentOS Linux 8 a été interrompue, du 31 mai 2029 au 31 décembre 2021."
+      },
+      "q": {
+        "come-in": "Quel est l'intérêt de Rocky Linux ?",
+        "downstream-partner-direction": "Que voulez-vous dire par \"son partenaire en aval a changé de direction\" ?"
+      }
+    }
   },
-  "landing": {
+
+  "download": {
     "p1": {
-      "content": " Un effort communautaire pour vous apporter une distribution Linux de qualité professionnelle, prêt pour la production.",
-      "heading": "Rocky Linux"
+      "heading": "Downloads",
+      "content": "Download the official release of Rocky Linux from one of our trusted mirrors."
+    },
+    "warning": "The release you can download here is a <i>Release Candidate</i> and should not be used in production. Please check our <a class=\"underline font-medium\" href=\"/faq/\">FAQ</a> for more information.",
+    "table": {
+      "architecture": "Architecture",
+      "iso": "ISOS",
+      "isos": {
+        "minimal": "Minimal",
+        "dvd": "DVD",
+        "boot": "Boot",
+        "checksum": "Checksum"
+      },
+      "packages": "Packages"
     },
     "p2": {
-      "content": "Rocky Linux est un système d'exploitation d'entreprise communautaire conçu pour être 100% compatible bogue pour bogue avec la principale distribution d'entreprise Linux américaine, maintenant que son partenaire en aval a changé de direction. Elle est en cours de développement intensif par la communauté. Rocky Linux est dirigé par Gregory Kurtzer, fondateur du projet CentOS. Il n'y a pas d'ETA pour une version. Les contributeurs sont invités à nous contacter en utilisant les options de communication proposées sur ce site.",
-      "heading": "Qu'est-ce que le projet Rocky Linux ?"
+      "content": "As you download and use Rocky Linux, the Rocky Enterprise Software Foundation invites you to <a class=\"text-green-600 dark:text-green-500 font-medium\" href=\"https://chat.rockylinux.org/\">be a part of the community as a contributor</a>. There are many ways to contribute to the project, from documentation, QA, and testing to coding changes for SIGs, providing mirroring or hosting, and helping other users."
     }
   },
+
   "lang": {
     "footer": {
       "choose-language": "Choisir une langue..."
     }
   },
-  "links": {
-    "close-menu": "Fermer le menu",
-    "documentation": "Documentation",
-    "get-in-touch": "Contactez-nous",
-    "get-involved": "S'engager",
-    "go-home": "Retour à l'accueil",
-    "join-the-discussion": "Participez aux discussions",
-    "posts": "Nouveautés",
-    "show-your-interest": "Faites part de votre intérêt",
-    "sponsors": "Sponsors",
-    "partners": "Partenaires",
-    "status": "Status des services",
-    "donate": "Don",
-    "store": "Boutique",
-    "press": "Presse",
-    "download": "Télécharger",
-    "com_charter": "Charte communautaire",
-    "org_structure": "Structure de l'Organisation",
-    "privacy": "Politique de confidentialité"
+
+  "errors": {
+    "404": {
+      "title": "Page non trouvée.",
+      "explanation": "La ressource demandée n'a pas pu être localisée. Veuillez réessayer."
+    }
   },
-  "socials": {
-    "forums": "Forums",
-    "github": "Github",
-    "reddit": "Reddit",
-    "mattermost": "Mattermost",
-    "twitter": "Twitter"
-  },
+
   "news": {
     "title": "Nouveautés",
     "description": "Restez au courant de l'avancée du projet Rocky Linux."
   },
+
   "press": {
     "title": "Presse",
     "description": "Voir l'actualité de Rocky dans la presse."
   },
+
   "sponsors": {
     "title": "Sponsors",
-    "description": "Nous souhaitons remercier nos sponsors de nous soutenir dans ce projet."
+    "description": "Nous souhaitons remercier nos sponsors de nous soutenir dans ce projet.",
+    "tag": {
+      "fsponsor": "Founding Sponsor",
+      "psponsor": "Principal Sponsor"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "45drives": {
+        "name": "45Drives",
+        "description": "45Drives offers enterprise storage solutions built on powerful & robust open-source software that allows customers to benefit from the cost savings & flexibility of off-the-shelf hardware. Check them out for a fully supported data storage solution at the best cost per terabyte!"
+      },
+      "opendrives": {
+        "name": "OpenDrives",
+        "description": "OpenDrives is a global provider of enterprise-grade, hyper-scalable, network-attached-storage (NAS) solutions. We deliver the highest performing solutions for our customers - to match individual performance needs - for the most robust, complex and mission-critical projects and workflows, on-premises and into the cloud."
+      },
+      "montavista": {
+        "name": "MontaVista",
+        "description": "MontaVista Software is the leader in embedded commercial Linux, supporting MontaVista CGX, Yocto Project®, CentOS and Rocky Linux. MontaVista offers Open Source Software expertise, commercial-quality Linux distros, cost-effective maintenance and support for 10+ year life-cycles."
+      },
+      "aws": {
+        "name": "Amazon Web Services",
+        "description": "The RESF utilizes AWS to run much of the underlying infrastructure critical to the development and deployment of the services supporting Rocky Linux. From Koji builders for x86_64 and aarch64 running in EC2 to SRPM blob storage in S3, AWS is foundational to much of what we do."
+      }
+    }
+  },
+
+  "partners": {
+    "title": "Partners",
+    "description": "Partners of the RESF represent ongoing relationships of strategic importance to the Rocky Linux project. Through dedication of engineering expertise, infrastructure resources, or other means, their support is critical to our continued success and long term stability.",
+    "tag": {
+      "fpartner": "Founding Partner",
+      "ppartner": "Principal Partner"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "navercloud": {
+        "name": "NAVER Cloud",
+        "description": "NAVER Cloud Platform is a South Korean cloud service that started in 2017 under NAVER Cloud, a subsidiary of NAVER. It provides over 170 individual services in 2021 and holds various security certifications including CSA STAR GOLD, GDPR, and more. It also currently provides cloud services in 10 locations around the world."
+      },
+      "mattermost": {
+        "name": "Mattermost",
+        "description": "Mattermost is an open source messaging solution made for organizations with the highest security requirements. As big believers in the power of open source, Mattermost is thrilled to partner with RESF to help bring an enterprise-grade distribution of Linux to the tech community."
+      }
+    }
+  },
+
+  "faq": {
+    "heading": "Frequently Asked Questions",
+    "q1": {
+      "q": "Where can I download the release candidate?",
+      "a": "https://rockylinux.org/download"
+    },
+    "q2": {
+      "q": "What is a release candidate?",
+      "a": "A release candidate is a beta version of a product that has the potential to be stable.The intent of a release candidate is for the community to test and validate expected functionality of Rocky Linux and report any bugs if present."
+    },
+    "q3": {
+      "q": "Can I use the release candidate in production?",
+      "a": "Under no circumstance should you use a release candidate in a production environment. A release candidate is provided for testing and validation purposes only."
+    },
+    "q4": {
+      "q": "How can I help mirror the release candidate and future Rocky Linux releases?",
+      "a": "Please email <a href=\"mailto:mirrors@rockylinux.org\">mirrors@rockylinux.org</a> to express your interest."
+    },
+    "q5": {
+      "q": "I encountered a bug while testing the release candidate, what can I do?",
+      "a": "First, create an account using <a href=\"https://accounts.rockylinux.org/\"> Rocky Linux Account Services </a> , then head over to our <a href=\"https://bugs.rockylinux.org/\">Bugzilla server</a> to report any bugs."
+    },
+    "q6": {
+      "q": "How can I get involved with the Testing team?",
+      "a": "Please join the <a href=\"https://chat.rockylinux.org/rocky-linux/channels/testing\"> ~Testing </a> channel on our Mattermost server to get started. There’s also a testing topic on the forums for more durable conversation."
+    },
+    "q7": {
+      "q": "Where can I find the latest news about Rocky Linux?",
+      "a": "Stay tuned to our website, Twitter, LinkedIn, forums, and other platforms listed in our link directory for the latest announcements."
+    },
+    "q8": {
+      "q": "If Rocky Linux is just a respin of RHEL, what took so long for a release candidate?",
+      "a1": "If our only goal for Rocky Linux was to debrand and repackage RHEL, we would have been done much sooner. However, what we had to do differently is figure out how we could keep Rocky Linux in the hands of the community. Carefully devising this strategy ensures that Rocky Linux will never meet the same fate of CentOS.",
+      "a2": "The goal was not just to create a community managed RPM based distribution of Linux, but to ensure that it will remain freely available and always in the control of the community, much like Linux itself has. To do that required more than a build infrastructure; it required that we put in place the foundational structures that enable the community, ensuring that Rocky Linux is forever inclusive, free, and open. The infrastructure is built from the ground up by many collaborators and sponsoring organizations around composability and security compliance, providing the substrate for not only the base operating system but also an entire community of diverse interests to take part in the project."
+    },
+    "q9": {
+      "q": "If you’re not just repackaging RHEL, then what exactly are you doing?",
+      "a": "Our goal is to maintain Rocky Linux as a community-oriented distribution <i>by</i> the community, <i>for</i> the community. To do this, we are establishing the necessary organizational structures to ensure that Rocky Linux remains in the hands of the community. We want to make sure that it’s not possible for what happened to CentOS to happen to Rocky Linux."
+    },
+    "q10": {
+      "q": "How will you ensure that Rocky Linux truly remains a community enterprise operating system?",
+      "a": "First, we’ve taken steps to legally protect the Rocky Linux name. This means registering its trademarks and various associated properties to protect them from being controlled by another entity. We’ve achieved this by establishing them under the Rocky Enterprise Software Foundation (RESF). Next, we’re drafting a community charter that will define the organizational structure, objectives, values, and mission behind the legal entity that represents Rocky Linux. Critical in this charter is the establishment of principles that enable and protect the community: transparency, community involvement, open development, and independence. <strong> Rocky Linux will never be controlled, purchased, or otherwise influenced by a single entity or organization. </strong> Finally, we’re architecting and deploying the necessary infrastructure to further enable the community to contribute to Rocky Linux."
+    },
+    "q11": {
+      "q": "What infrastructure is necessary to enable the community?",
+      "a1": "We’ve established a number of teams to support the various efforts associated with developing Rocky Linux:",
+      "a2": "You can read more about this structure when it’s soon published. In order to enable collaboration across and within those teams, we needed to deploy our own chat infrastructure, forums, and website. Additionally, we’re also creating our build infrastructure, which will facilitate the development of the core operating system.",
+      "list": {
+        "community": "Community",
+        "core-inf": "Core Infrastructure",
+        "design": "Design",
+        "documentation": "Documentation",
+        "installer": "Installer",
+        "leadership": "Leadership",
+        "pkg-autob": "Package Auto-Builders",
+        "packaging": "Packaging",
+        "security": "Security",
+        "sigs": "Special Interest Groups (SIGs)",
+        "web": "Web"
+      }
+    },
+    "q12": {
+      "q": "Why does it take so much time to stand up a community and build infrastructure?",
+      "a": "It’s not terribly difficult to deploy a website, forums, or a build infrastructure in a reliable fashion. Our chat program for instance, which uses Mattermost, is distributed on a number of application servers behind a load balancer and was ready in just a couple of weeks. But it does require careful thought and planning to do it in a scalable and secure manner when you need to ensure vendor and platform agnosticity and long-term community involvement."
+    },
+    "q13": {
+      "q": "So what’s the short answer to all of this? What are some things you’re thinking about as you put Rocky Linux together?",
+      "a": "How do we carefully shepherd community trust? How do we ensure that anyone who wants to participate can not only do so immediately, but forever in the future as well? How do we engage and enable the community members who might not be as technical but want to contribute anyway? Solving for all of these challenges will take time, and we would love your help in doing so."
+    },
+    "q14": {
+      "q": "What if I have feedback or my question wasn’t answered here?",
+      "a": "Please email us: <a href=\"mailto:hello@rockylinux.org\">hello@rockylinux.org</a> and we’ll get back to you as soon as we can."
+    }
   }
 }

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -51,7 +51,10 @@
     "donate": "Don",
     "store": "Boutique",
     "press": "Presse",
-    "download": "Télécharger"
+    "download": "Télécharger",
+    "com_charter": "Charte communautaire",
+    "org_structure": "Structure de l'Organisation",
+    "privacy": "Politique de confidentialité"
   },
   "socials": {
     "forums": "Forums",

--- a/src/i18n/locales/id/translation.json
+++ b/src/i18n/locales/id/translation.json
@@ -1,72 +1,241 @@
 {
   "language": "id",
-  "copyright": {
-    "line1": "© 2021 Seluruh hak cipta. Proyek Rocky Linux. ",
-    "line2": "CentOS adalah merek dagang terdaftar dari Red Hat, Inc. Proyek Rocky Linux tidak berafiliasi dengan, atau didukung oleh Red Hat, Inc."
-  },
-  "errors": {
-    "404": {
-      "explanation": "Sumber daya yang diminta tidak dapat ditemukan. Silahkan coba lagi.",
-      "title": "Halaman tidak ditemukan."
+
+  "global": {
+
+    "copyright": {
+      "line1": "© 2021 Seluruh hak cipta. Proyek Rocky Linux. ",
+      "line2": "CentOS adalah merek dagang terdaftar dari Red Hat, Inc. Proyek Rocky Linux tidak berafiliasi dengan, atau didukung oleh Red Hat, Inc."
+    },
+
+    "links": {
+      "close-menu": "Tutup menu",
+      "wiki": "Wiki",
+      "get-in-touch": "Hubungi Kami",
+      "get-involved": "Terlibat",
+      "go-home": "Ke Beranda",
+      "join-the-discussion": "Bergabung dengan Diskusi",
+      "posts": "News",
+      "show-your-interest": "Show Your Interest",
+      "sponsors": "Sponsors",
+      "partners": "Partners",
+      "status": "Service Status",
+      "donate": "Donate",
+      "store": "Store",
+      "press": "Press",
+      "download": "Download",
+      "com_charter": "Community Charter",
+      "org_structure": "Organization Structure",
+      "privacy": "Privacy Policy",
+      "see-more": "See More",
+      "see-all": "See All",
+      "documentation": "Dokumentasi",
+      "bug-report": "Report a bug"
+    },
+    "socials": {
+      "forums": "Forums",
+      "github": "Github",
+      "reddit": "Reddit",
+      "mattermost": "Mattermost",
+      "twitter": "Twitter"
     }
   },
-  "faq": {
-    "a": {
-      "come-in": "Rocky Linux bertujuan untuk berfungsi sebagai build hilir seperti yang dilakukan CentOS sebelumnya, rilis build setelah ditambahkan oleh vendor hulu, bukan sebelumnya.",
-      "downstream-partner-direction": "Proyek CentOS baru-baru ini mengumumkan perubahan strategi untuk CentOS. Jika sebelumnya CentOS ada sebagai build hilir dari vendor hulu (menerima tambalan dan pembaruan setelah vendor hulu melakukannya), itu akan bergeser ke versi hulu (menguji tambalan dan pembaruan sebelum disertakan di vendor hulu). Selain itu, dukungan untuk CentOS Linux 8 telah dihentikan, dari 31 Mei 2029 hingga 31 Desember 2021."
+
+  "homepage": {
+    "landing": {
+      "p1": {
+        "heading": "Rocky Linux",
+        "content": "Upaya berbasis komunitas untuk menghadirkan Linux tingkat perusahaan dan siap produksi untuk Anda."
+      },
+      "p2": {
+        "heading": "Apa itu Proyek Rocky Linux?",
+        "content": "Rocky Linux adalah sistem operasi perusahaan komunitas yang dirancang agar 100% kutu demi kutu kompatibel dengan distribusi Linux perusahaan teratas Amerika sekarang setelah mitra hilirnya telah bergeser arah. Itu sedang dalam pengembangan intensif oleh komunitas. Rocky Linux dipimpin oleh Gregory Kurtzer, pendiri proyek CentOS. Tidak ada perkiraan waktu untuk rilis. Kontributor diminta untuk menghubungi menggunakan opsi komunikasi yang ditawarkan di situs ini."
+      }
     },
-    "q": {
-      "come-in": "Jadi dari mana Rocky Linux masuk?",
-      "downstream-partner-direction": "Apa maksud Anda, \"mitra hilirnya telah bergeser arah?\""
-    },
-    "title": "Pertanyaan yang Sering Diajukan"
+    "faq": {
+      "title": "Pertanyaan yang Sering Diajukan",
+      "a": {
+        "come-in": "Rocky Linux bertujuan untuk berfungsi sebagai build hilir seperti yang dilakukan CentOS sebelumnya, rilis build setelah ditambahkan oleh vendor hulu, bukan sebelumnya.",
+        "downstream-partner-direction": "Proyek CentOS baru-baru ini mengumumkan perubahan strategi untuk CentOS. Jika sebelumnya CentOS ada sebagai build hilir dari vendor hulu (menerima tambalan dan pembaruan setelah vendor hulu melakukannya), itu akan bergeser ke versi hulu (menguji tambalan dan pembaruan sebelum disertakan di vendor hulu). Selain itu, dukungan untuk CentOS Linux 8 telah dihentikan, dari 31 Mei 2029 hingga 31 Desember 2021."
+      },
+      "q": {
+        "come-in": "Jadi dari mana Rocky Linux masuk?",
+        "downstream-partner-direction": "Apa maksud Anda, \"mitra hilirnya telah bergeser arah?\""
+      }
+    }
   },
-  "landing": {
+
+  "download": {
     "p1": {
-      "content": "Upaya berbasis komunitas untuk menghadirkan Linux tingkat perusahaan dan siap produksi untuk Anda.",
-      "heading": "Rocky Linux"
+      "heading": "Downloads",
+      "content": "Download the official release of Rocky Linux from one of our trusted mirrors."
+    },
+    "warning": "The release you can download here is a <i>Release Candidate</i> and should not be used in production. Please check our <a class=\"underline font-medium\" href=\"/faq/\">FAQ</a> for more information.",
+    "table": {
+      "architecture": "Architecture",
+      "iso": "ISOS",
+      "isos": {
+        "minimal": "Minimal",
+        "dvd": "DVD",
+        "boot": "Boot",
+        "checksum": "Checksum"
+      },
+      "packages": "Packages"
     },
     "p2": {
-      "content": "Rocky Linux adalah sistem operasi perusahaan komunitas yang dirancang agar 100% kutu demi kutu kompatibel dengan distribusi Linux perusahaan teratas Amerika sekarang setelah mitra hilirnya telah bergeser arah. Itu sedang dalam pengembangan intensif oleh komunitas. Rocky Linux dipimpin oleh Gregory Kurtzer, pendiri proyek CentOS. Tidak ada perkiraan waktu untuk rilis. Kontributor diminta untuk menghubungi menggunakan opsi komunikasi yang ditawarkan di situs ini.",
-      "heading": "Apa itu Proyek Rocky Linux?"
+      "content": "As you download and use Rocky Linux, the Rocky Enterprise Software Foundation invites you to <a class=\"text-green-600 dark:text-green-500 font-medium\" href=\"https://chat.rockylinux.org/\">be a part of the community as a contributor</a>. There are many ways to contribute to the project, from documentation, QA, and testing to coding changes for SIGs, providing mirroring or hosting, and helping other users."
     }
   },
+
   "lang": {
     "footer": {
       "choose-language": "Pilih bahasa ..."
     }
   },
-  "links": {
-    "close-menu": "Tutup menu",
-    "documentation": "Dokumentasi",
-    "get-in-touch": "Hubungi Kami",
-    "get-involved": "Terlibat",
-    "go-home": "Ke Beranda",
-    "join-the-discussion": "Bergabung dengan Diskusi",
-    "posts": "News",
-    "show-your-interest": "Show Your Interest",
-    "sponsors": "Sponsors",
-    "donate": "Donate",
-    "store": "Store",
-    "press": "Press"
+
+  "errors": {
+    "404": {
+      "title": "Halaman tidak ditemukan.",
+      "explanation": "Sumber daya yang diminta tidak dapat ditemukan. Silahkan coba lagi."
+    }
   },
-  "socials": {
-    "forums": "Forum",
-    "github": "Github",
-    "reddit": "Reddit",
-    "mattermost": "Mattermost",
-    "twitter": "Twitter"
-  },
+
   "news": {
     "title": "News",
     "description": "Stay up-to-date on the latest from The Rocky Linux Project."
   },
+
   "press": {
     "title": "Press",
     "description": "See the latest about Rocky in the press."
   },
+
   "sponsors": {
     "title": "Sponsors",
-    "description": "We would like to thank our sponsors for their support thus far on the project."
+    "description": "We would like to thank our sponsors for their support thus far on the project.",
+    "tag": {
+      "fsponsor": "Founding Sponsor",
+      "psponsor": "Principal Sponsor"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "45drives": {
+        "name": "45Drives",
+        "description": "45Drives offers enterprise storage solutions built on powerful & robust open-source software that allows customers to benefit from the cost savings & flexibility of off-the-shelf hardware. Check them out for a fully supported data storage solution at the best cost per terabyte!"
+      },
+      "opendrives": {
+        "name": "OpenDrives",
+        "description": "OpenDrives is a global provider of enterprise-grade, hyper-scalable, network-attached-storage (NAS) solutions. We deliver the highest performing solutions for our customers - to match individual performance needs - for the most robust, complex and mission-critical projects and workflows, on-premises and into the cloud."
+      },
+      "montavista": {
+        "name": "MontaVista",
+        "description": "MontaVista Software is the leader in embedded commercial Linux, supporting MontaVista CGX, Yocto Project®, CentOS and Rocky Linux. MontaVista offers Open Source Software expertise, commercial-quality Linux distros, cost-effective maintenance and support for 10+ year life-cycles."
+      },
+      "aws": {
+        "name": "Amazon Web Services",
+        "description": "The RESF utilizes AWS to run much of the underlying infrastructure critical to the development and deployment of the services supporting Rocky Linux. From Koji builders for x86_64 and aarch64 running in EC2 to SRPM blob storage in S3, AWS is foundational to much of what we do."
+      }
+    }
+  },
+
+  "partners": {
+    "title": "Partners",
+    "description": "Partners of the RESF represent ongoing relationships of strategic importance to the Rocky Linux project. Through dedication of engineering expertise, infrastructure resources, or other means, their support is critical to our continued success and long term stability.",
+    "tag": {
+      "fpartner": "Founding Partner",
+      "ppartner": "Principal Partner"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "navercloud": {
+        "name": "NAVER Cloud",
+        "description": "NAVER Cloud Platform is a South Korean cloud service that started in 2017 under NAVER Cloud, a subsidiary of NAVER. It provides over 170 individual services in 2021 and holds various security certifications including CSA STAR GOLD, GDPR, and more. It also currently provides cloud services in 10 locations around the world."
+      },
+      "mattermost": {
+        "name": "Mattermost",
+        "description": "Mattermost is an open source messaging solution made for organizations with the highest security requirements. As big believers in the power of open source, Mattermost is thrilled to partner with RESF to help bring an enterprise-grade distribution of Linux to the tech community."
+      }
+    }
+  },
+
+  "faq": {
+    "heading": "Frequently Asked Questions",
+    "q1": {
+      "q": "Where can I download the release candidate?",
+      "a": "https://rockylinux.org/download"
+    },
+    "q2": {
+      "q": "What is a release candidate?",
+      "a": "A release candidate is a beta version of a product that has the potential to be stable.The intent of a release candidate is for the community to test and validate expected functionality of Rocky Linux and report any bugs if present."
+    },
+    "q3": {
+      "q": "Can I use the release candidate in production?",
+      "a": "Under no circumstance should you use a release candidate in a production environment. A release candidate is provided for testing and validation purposes only."
+    },
+    "q4": {
+      "q": "How can I help mirror the release candidate and future Rocky Linux releases?",
+      "a": "Please email <a href=\"mailto:mirrors@rockylinux.org\">mirrors@rockylinux.org</a> to express your interest."
+    },
+    "q5": {
+      "q": "I encountered a bug while testing the release candidate, what can I do?",
+      "a": "First, create an account using <a href=\"https://accounts.rockylinux.org/\"> Rocky Linux Account Services </a> , then head over to our <a href=\"https://bugs.rockylinux.org/\">Bugzilla server</a> to report any bugs."
+    },
+    "q6": {
+      "q": "How can I get involved with the Testing team?",
+      "a": "Please join the <a href=\"https://chat.rockylinux.org/rocky-linux/channels/testing\"> ~Testing </a> channel on our Mattermost server to get started. There’s also a testing topic on the forums for more durable conversation."
+    },
+    "q7": {
+      "q": "Where can I find the latest news about Rocky Linux?",
+      "a": "Stay tuned to our website, Twitter, LinkedIn, forums, and other platforms listed in our link directory for the latest announcements."
+    },
+    "q8": {
+      "q": "If Rocky Linux is just a respin of RHEL, what took so long for a release candidate?",
+      "a1": "If our only goal for Rocky Linux was to debrand and repackage RHEL, we would have been done much sooner. However, what we had to do differently is figure out how we could keep Rocky Linux in the hands of the community. Carefully devising this strategy ensures that Rocky Linux will never meet the same fate of CentOS.",
+      "a2": "The goal was not just to create a community managed RPM based distribution of Linux, but to ensure that it will remain freely available and always in the control of the community, much like Linux itself has. To do that required more than a build infrastructure; it required that we put in place the foundational structures that enable the community, ensuring that Rocky Linux is forever inclusive, free, and open. The infrastructure is built from the ground up by many collaborators and sponsoring organizations around composability and security compliance, providing the substrate for not only the base operating system but also an entire community of diverse interests to take part in the project."
+    },
+    "q9": {
+      "q": "If you’re not just repackaging RHEL, then what exactly are you doing?",
+      "a": "Our goal is to maintain Rocky Linux as a community-oriented distribution <i>by</i> the community, <i>for</i> the community. To do this, we are establishing the necessary organizational structures to ensure that Rocky Linux remains in the hands of the community. We want to make sure that it’s not possible for what happened to CentOS to happen to Rocky Linux."
+    },
+    "q10": {
+      "q": "How will you ensure that Rocky Linux truly remains a community enterprise operating system?",
+      "a": "First, we’ve taken steps to legally protect the Rocky Linux name. This means registering its trademarks and various associated properties to protect them from being controlled by another entity. We’ve achieved this by establishing them under the Rocky Enterprise Software Foundation (RESF). Next, we’re drafting a community charter that will define the organizational structure, objectives, values, and mission behind the legal entity that represents Rocky Linux. Critical in this charter is the establishment of principles that enable and protect the community: transparency, community involvement, open development, and independence. <strong> Rocky Linux will never be controlled, purchased, or otherwise influenced by a single entity or organization. </strong> Finally, we’re architecting and deploying the necessary infrastructure to further enable the community to contribute to Rocky Linux."
+    },
+    "q11": {
+      "q": "What infrastructure is necessary to enable the community?",
+      "a1": "We’ve established a number of teams to support the various efforts associated with developing Rocky Linux:",
+      "a2": "You can read more about this structure when it’s soon published. In order to enable collaboration across and within those teams, we needed to deploy our own chat infrastructure, forums, and website. Additionally, we’re also creating our build infrastructure, which will facilitate the development of the core operating system.",
+      "list": {
+        "community": "Community",
+        "core-inf": "Core Infrastructure",
+        "design": "Design",
+        "documentation": "Documentation",
+        "installer": "Installer",
+        "leadership": "Leadership",
+        "pkg-autob": "Package Auto-Builders",
+        "packaging": "Packaging",
+        "security": "Security",
+        "sigs": "Special Interest Groups (SIGs)",
+        "web": "Web"
+      }
+    },
+    "q12": {
+      "q": "Why does it take so much time to stand up a community and build infrastructure?",
+      "a": "It’s not terribly difficult to deploy a website, forums, or a build infrastructure in a reliable fashion. Our chat program for instance, which uses Mattermost, is distributed on a number of application servers behind a load balancer and was ready in just a couple of weeks. But it does require careful thought and planning to do it in a scalable and secure manner when you need to ensure vendor and platform agnosticity and long-term community involvement."
+    },
+    "q13": {
+      "q": "So what’s the short answer to all of this? What are some things you’re thinking about as you put Rocky Linux together?",
+      "a": "How do we carefully shepherd community trust? How do we ensure that anyone who wants to participate can not only do so immediately, but forever in the future as well? How do we engage and enable the community members who might not be as technical but want to contribute anyway? Solving for all of these challenges will take time, and we would love your help in doing so."
+    },
+    "q14": {
+      "q": "What if I have feedback or my question wasn’t answered here?",
+      "a": "Please email us: <a href=\"mailto:hello@rockylinux.org\">hello@rockylinux.org</a> and we’ll get back to you as soon as we can."
+    }
   }
 }

--- a/src/i18n/locales/it/translation.json
+++ b/src/i18n/locales/it/translation.json
@@ -1,72 +1,241 @@
 {
   "language": "it",
-  "copyright": {
-    "line1": "© 2021 The Rocky Linux Project. Tutti i diritti riservati ",
-    "line2": "CentOS è un marchio registrato di Red Hat, Inc. Il Rocky Linux Project non è affiliato a, né approvato da Red Hat, Inc."
-  },
-  "errors": {
-    "404": {
-      "explanation": "La risorsa richiesta non è stata trovata. Si prega di riprovare.",
-      "title": "Pagina non trovata."
+
+  "global": {
+
+    "copyright": {
+      "line1": "© 2021 The Rocky Linux Project. Tutti i diritti riservati ",
+      "line2": "CentOS è un marchio registrato di Red Hat, Inc. Il Rocky Linux Project non è affiliato a, né approvato da Red Hat, Inc."
+    },
+
+    "links": {
+      "close-menu": "Chiudi il menù",
+      "wiki": "Wiki",
+      "get-in-touch": "Contattaci",
+      "get-involved": "Partecipa",
+      "go-home": "Link iniziale",
+      "join-the-discussion": "Partecipa alla discussione",
+      "posts": "News",
+      "show-your-interest": "Show Your Interest",
+      "sponsors": "Sponsors",
+      "partners": "Partners",
+      "status": "Service Status",
+      "donate": "Donate",
+      "store": "Store",
+      "press": "Press",
+      "download": "Download",
+      "com_charter": "Community Charter",
+      "org_structure": "Organization Structure",
+      "privacy": "Privacy Policy",
+      "see-more": "See More",
+      "see-all": "See All",
+      "documentation": "Documentazione",
+      "bug-report": "Report a bug"
+    },
+    "socials": {
+      "forums": "Forums",
+      "github": "Github",
+      "reddit": "Reddit",
+      "mattermost": "Mattermost",
+      "twitter": "Twitter"
     }
   },
-  "faq": {
-    "a": {
-      "come-in": "Rocky Linux mira a essere una distribuzione downstream come CentOS aveva fatto in precedenza: le release verranno create partendo dalla distribuzione upstream, non prima.",
-      "downstream-partner-direction": "Il progetto CentOS ha recentemente cambiato strategia. In precedenza CentOS esisteva come una downstream build della distribuzione upstream upstream (riceve le patch e gli aggiornamenti dopo la distribuzione upstream). Ora passerà ad essere una upstream build  (test delle patch e degli aggiornamenti prima dell'inclusione nell' upstream). Inoltre, il supporto per CentOS Linux 8 è stato ridotto, dal 31 maggio 2029 al 31 dicembre 2021."
+
+  "homepage": {
+    "landing": {
+      "p1": {
+        "heading": "Rocky Linux",
+        "content": "Uno sforzo guidato dalla comunità per portarvi una distribuzione Linux di livello enterprise, pronto per la produzione."
+      },
+      "p2": {
+        "heading": "Cos'è Rocky Linux Project?",
+        "content": "Rocky Linux è una distribuzione Linux gratuita progettata per essere compatibile al 100% con la migliore distribuzione Linux aziendale americana (!) ora che il suo partner downstream CentOS ha cambiato direzione. È in fase di intenso sviluppo da parte della comunità. Rocky Linux è guidata da Gregory Kurtzer, fondatore del progetto CentOS. Non c'è un ETA per una release. I contributori sono invitati a contattare gli utenti utilizzando le opzioni di comunicazione offerte su questo sito."
+      }
     },
-    "q": {
-      "come-in": "Quindi, dove entra in gioco Rocky Linux?",
-      "downstream-partner-direction": "Cosa si intende con \"il suo partner downstream ha cambiato direzione\"?"
-    },
-    "title": "Domande frequenti"
+    "faq": {
+      "title": "Domande frequenti",
+      "a": {
+        "come-in": "Rocky Linux mira a essere una distribuzione downstream come CentOS aveva fatto in precedenza: le release verranno create partendo dalla distribuzione upstream, non prima.",
+        "downstream-partner-direction": "Il progetto CentOS ha recentemente cambiato strategia. In precedenza CentOS esisteva come una downstream build della distribuzione upstream upstream (riceve le patch e gli aggiornamenti dopo la distribuzione upstream). Ora passerà ad essere una upstream build  (test delle patch e degli aggiornamenti prima dell'inclusione nell' upstream). Inoltre, il supporto per CentOS Linux 8 è stato ridotto, dal 31 maggio 2029 al 31 dicembre 2021."
+      },
+      "q": {
+        "come-in": "Quindi, dove entra in gioco Rocky Linux?",
+        "downstream-partner-direction": "Cosa si intende con \"il suo partner downstream ha cambiato direzione\"?"
+      }
+    }
   },
-  "landing": {
+
+  "download": {
     "p1": {
-      "content": "Uno sforzo guidato dalla comunità per portarvi una distribuzione Linux di livello enterprise, pronto per la produzione.",
-      "heading": "Rocky Linux"
+      "heading": "Downloads",
+      "content": "Download the official release of Rocky Linux from one of our trusted mirrors."
+    },
+    "warning": "The release you can download here is a <i>Release Candidate</i> and should not be used in production. Please check our <a class=\"underline font-medium\" href=\"/faq/\">FAQ</a> for more information.",
+    "table": {
+      "architecture": "Architecture",
+      "iso": "ISOS",
+      "isos": {
+        "minimal": "Minimal",
+        "dvd": "DVD",
+        "boot": "Boot",
+        "checksum": "Checksum"
+      },
+      "packages": "Packages"
     },
     "p2": {
-      "content": "Rocky Linux è una distribuzione Linux gratuita progettata per essere compatibile al 100% con la migliore distribuzione Linux aziendale americana (!) ora che il suo partner downstream CentOS ha cambiato direzione. È in fase di intenso sviluppo da parte della comunità. Rocky Linux è guidata da Gregory Kurtzer, fondatore del progetto CentOS. Non c'è un ETA per una release. I contributori sono invitati a contattare gli utenti utilizzando le opzioni di comunicazione offerte su questo sito.",
-      "heading": "Cos'è Rocky Linux Project?"
+      "content": "As you download and use Rocky Linux, the Rocky Enterprise Software Foundation invites you to <a class=\"text-green-600 dark:text-green-500 font-medium\" href=\"https://chat.rockylinux.org/\">be a part of the community as a contributor</a>. There are many ways to contribute to the project, from documentation, QA, and testing to coding changes for SIGs, providing mirroring or hosting, and helping other users."
     }
   },
+
   "lang": {
     "footer": {
       "choose-language": "Scegli una lingua..."
     }
   },
-  "links": {
-    "close-menu": "Chiudi il menù",
-    "documentation": "Documentazione",
-    "get-in-touch": "Contattaci",
-    "get-involved": "Partecipa",
-    "go-home": "Link iniziale",
-    "join-the-discussion": "Partecipa alla discussione",
-    "posts": "News",
-    "show-your-interest": "Show Your Interest",
-    "sponsors": "Sponsors",
-    "donate": "Donate",
-    "store": "Store",
-    "press": "Press"
+
+  "errors": {
+    "404": {
+      "title": "Pagina non trovata.",
+      "explanation": "La risorsa richiesta non è stata trovata. Si prega di riprovare."
+    }
   },
-  "socials": {
-    "forums": "Forums",
-    "github": "Github",
-    "reddit": "Reddit",
-    "mattermost": "Mattermost",
-    "twitter": "Twitter"
-  },
+
   "news": {
     "title": "News",
     "description": "Stay up-to-date on the latest from The Rocky Linux Project."
   },
+
   "press": {
     "title": "Press",
     "description": "See the latest about Rocky in the press."
   },
+
   "sponsors": {
     "title": "Sponsors",
-    "description": "We would like to thank our sponsors for their support thus far on the project."
+    "description": "We would like to thank our sponsors for their support thus far on the project.",
+    "tag": {
+      "fsponsor": "Founding Sponsor",
+      "psponsor": "Principal Sponsor"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "45drives": {
+        "name": "45Drives",
+        "description": "45Drives offers enterprise storage solutions built on powerful & robust open-source software that allows customers to benefit from the cost savings & flexibility of off-the-shelf hardware. Check them out for a fully supported data storage solution at the best cost per terabyte!"
+      },
+      "opendrives": {
+        "name": "OpenDrives",
+        "description": "OpenDrives is a global provider of enterprise-grade, hyper-scalable, network-attached-storage (NAS) solutions. We deliver the highest performing solutions for our customers - to match individual performance needs - for the most robust, complex and mission-critical projects and workflows, on-premises and into the cloud."
+      },
+      "montavista": {
+        "name": "MontaVista",
+        "description": "MontaVista Software is the leader in embedded commercial Linux, supporting MontaVista CGX, Yocto Project®, CentOS and Rocky Linux. MontaVista offers Open Source Software expertise, commercial-quality Linux distros, cost-effective maintenance and support for 10+ year life-cycles."
+      },
+      "aws": {
+        "name": "Amazon Web Services",
+        "description": "The RESF utilizes AWS to run much of the underlying infrastructure critical to the development and deployment of the services supporting Rocky Linux. From Koji builders for x86_64 and aarch64 running in EC2 to SRPM blob storage in S3, AWS is foundational to much of what we do."
+      }
+    }
+  },
+
+  "partners": {
+    "title": "Partners",
+    "description": "Partners of the RESF represent ongoing relationships of strategic importance to the Rocky Linux project. Through dedication of engineering expertise, infrastructure resources, or other means, their support is critical to our continued success and long term stability.",
+    "tag": {
+      "fpartner": "Founding Partner",
+      "ppartner": "Principal Partner"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "navercloud": {
+        "name": "NAVER Cloud",
+        "description": "NAVER Cloud Platform is a South Korean cloud service that started in 2017 under NAVER Cloud, a subsidiary of NAVER. It provides over 170 individual services in 2021 and holds various security certifications including CSA STAR GOLD, GDPR, and more. It also currently provides cloud services in 10 locations around the world."
+      },
+      "mattermost": {
+        "name": "Mattermost",
+        "description": "Mattermost is an open source messaging solution made for organizations with the highest security requirements. As big believers in the power of open source, Mattermost is thrilled to partner with RESF to help bring an enterprise-grade distribution of Linux to the tech community."
+      }
+    }
+  },
+
+  "faq": {
+    "heading": "Frequently Asked Questions",
+    "q1": {
+      "q": "Where can I download the release candidate?",
+      "a": "https://rockylinux.org/download"
+    },
+    "q2": {
+      "q": "What is a release candidate?",
+      "a": "A release candidate is a beta version of a product that has the potential to be stable.The intent of a release candidate is for the community to test and validate expected functionality of Rocky Linux and report any bugs if present."
+    },
+    "q3": {
+      "q": "Can I use the release candidate in production?",
+      "a": "Under no circumstance should you use a release candidate in a production environment. A release candidate is provided for testing and validation purposes only."
+    },
+    "q4": {
+      "q": "How can I help mirror the release candidate and future Rocky Linux releases?",
+      "a": "Please email <a href=\"mailto:mirrors@rockylinux.org\">mirrors@rockylinux.org</a> to express your interest."
+    },
+    "q5": {
+      "q": "I encountered a bug while testing the release candidate, what can I do?",
+      "a": "First, create an account using <a href=\"https://accounts.rockylinux.org/\"> Rocky Linux Account Services </a> , then head over to our <a href=\"https://bugs.rockylinux.org/\">Bugzilla server</a> to report any bugs."
+    },
+    "q6": {
+      "q": "How can I get involved with the Testing team?",
+      "a": "Please join the <a href=\"https://chat.rockylinux.org/rocky-linux/channels/testing\"> ~Testing </a> channel on our Mattermost server to get started. There’s also a testing topic on the forums for more durable conversation."
+    },
+    "q7": {
+      "q": "Where can I find the latest news about Rocky Linux?",
+      "a": "Stay tuned to our website, Twitter, LinkedIn, forums, and other platforms listed in our link directory for the latest announcements."
+    },
+    "q8": {
+      "q": "If Rocky Linux is just a respin of RHEL, what took so long for a release candidate?",
+      "a1": "If our only goal for Rocky Linux was to debrand and repackage RHEL, we would have been done much sooner. However, what we had to do differently is figure out how we could keep Rocky Linux in the hands of the community. Carefully devising this strategy ensures that Rocky Linux will never meet the same fate of CentOS.",
+      "a2": "The goal was not just to create a community managed RPM based distribution of Linux, but to ensure that it will remain freely available and always in the control of the community, much like Linux itself has. To do that required more than a build infrastructure; it required that we put in place the foundational structures that enable the community, ensuring that Rocky Linux is forever inclusive, free, and open. The infrastructure is built from the ground up by many collaborators and sponsoring organizations around composability and security compliance, providing the substrate for not only the base operating system but also an entire community of diverse interests to take part in the project."
+    },
+    "q9": {
+      "q": "If you’re not just repackaging RHEL, then what exactly are you doing?",
+      "a": "Our goal is to maintain Rocky Linux as a community-oriented distribution <i>by</i> the community, <i>for</i> the community. To do this, we are establishing the necessary organizational structures to ensure that Rocky Linux remains in the hands of the community. We want to make sure that it’s not possible for what happened to CentOS to happen to Rocky Linux."
+    },
+    "q10": {
+      "q": "How will you ensure that Rocky Linux truly remains a community enterprise operating system?",
+      "a": "First, we’ve taken steps to legally protect the Rocky Linux name. This means registering its trademarks and various associated properties to protect them from being controlled by another entity. We’ve achieved this by establishing them under the Rocky Enterprise Software Foundation (RESF). Next, we’re drafting a community charter that will define the organizational structure, objectives, values, and mission behind the legal entity that represents Rocky Linux. Critical in this charter is the establishment of principles that enable and protect the community: transparency, community involvement, open development, and independence. <strong> Rocky Linux will never be controlled, purchased, or otherwise influenced by a single entity or organization. </strong> Finally, we’re architecting and deploying the necessary infrastructure to further enable the community to contribute to Rocky Linux."
+    },
+    "q11": {
+      "q": "What infrastructure is necessary to enable the community?",
+      "a1": "We’ve established a number of teams to support the various efforts associated with developing Rocky Linux:",
+      "a2": "You can read more about this structure when it’s soon published. In order to enable collaboration across and within those teams, we needed to deploy our own chat infrastructure, forums, and website. Additionally, we’re also creating our build infrastructure, which will facilitate the development of the core operating system.",
+      "list": {
+        "community": "Community",
+        "core-inf": "Core Infrastructure",
+        "design": "Design",
+        "documentation": "Documentation",
+        "installer": "Installer",
+        "leadership": "Leadership",
+        "pkg-autob": "Package Auto-Builders",
+        "packaging": "Packaging",
+        "security": "Security",
+        "sigs": "Special Interest Groups (SIGs)",
+        "web": "Web"
+      }
+    },
+    "q12": {
+      "q": "Why does it take so much time to stand up a community and build infrastructure?",
+      "a": "It’s not terribly difficult to deploy a website, forums, or a build infrastructure in a reliable fashion. Our chat program for instance, which uses Mattermost, is distributed on a number of application servers behind a load balancer and was ready in just a couple of weeks. But it does require careful thought and planning to do it in a scalable and secure manner when you need to ensure vendor and platform agnosticity and long-term community involvement."
+    },
+    "q13": {
+      "q": "So what’s the short answer to all of this? What are some things you’re thinking about as you put Rocky Linux together?",
+      "a": "How do we carefully shepherd community trust? How do we ensure that anyone who wants to participate can not only do so immediately, but forever in the future as well? How do we engage and enable the community members who might not be as technical but want to contribute anyway? Solving for all of these challenges will take time, and we would love your help in doing so."
+    },
+    "q14": {
+      "q": "What if I have feedback or my question wasn’t answered here?",
+      "a": "Please email us: <a href=\"mailto:hello@rockylinux.org\">hello@rockylinux.org</a> and we’ll get back to you as soon as we can."
+    }
   }
 }

--- a/src/i18n/locales/ja/translation.json
+++ b/src/i18n/locales/ja/translation.json
@@ -1,72 +1,241 @@
 {
   "language": "ja",
-  "copyright": {
-    "line1": "© 2021 The Rocky Linux Project. All rights reserved.",
-    "line2": "CentOS は Red Hat, Inc.の登録商標です。Rocky Linux Project は Red Hat, Inc.と提携しておらず、また Red Hat, Inc.が推奨しているものではありません。"
-  },
-  "errors": {
-    "404": {
-      "explanation": "指定されたURLが見つかりませんでした。もう一度お試しください。",
-      "title": "Page not found."
+
+  "global": {
+
+    "copyright": {
+      "line1": "© 2021 Rocky Enterprise Software Foundation. All rights reserved.",
+      "line2": "CentOS は Red Hat, Inc.の登録商標です。Rocky Linux Project は Red Hat, Inc.と提携しておらず、また Red Hat, Inc.が推奨しているものではありません。"
+    },
+
+    "links": {
+      "close-menu": "メニューを閉じる",
+      "wiki": "Wiki",
+      "get-in-touch": "お問い合わせ",
+      "get-involved": "参加する",
+      "go-home": "ホームに戻る",
+      "join-the-discussion": "議論に参加する",
+      "posts": "News",
+      "show-your-interest": "Show Your Interest",
+      "sponsors": "Sponsors",
+      "partners": "Partners",
+      "status": "Service Status",
+      "donate": "Donate",
+      "store": "Store",
+      "press": "Press",
+      "download": "Download",
+      "com_charter": "Community Charter",
+      "org_structure": "Organization Structure",
+      "privacy": "Privacy Policy",
+      "see-more": "See More",
+      "see-all": "See All",
+      "documentation": "ドキュメント",
+      "bug-report": "Report a bug"
+    },
+    "socials": {
+      "forums": "Forums",
+      "github": "Github",
+      "reddit": "Reddit",
+      "mattermost": "Mattermost",
+      "twitter": "Twitter"
     }
   },
-  "faq": {
-    "a": {
-      "come-in": "Rocky Linuxは、以前にCentOSが行っていたように、リリースが追加される前ではなく、アップストリームベンダによって追加された後にリリースをビルドすることで、ダウンストリームビルドとして機能することを目指しています。",
-      "downstream-partner-direction": "CentOSプロジェクトは最近、CentOSの戦略の転換を発表しました。これまでCentOSは、アップストリームベンダーのダウンストリームビルドとして存在していたのに対し（アップストリームベンダーがパッチを適用した後にパッチ適用やアップデートを行う）、アップストリームビルド（アップストリームベンダーに組み込む前にパッチやアップデートをテストする）に移行するとしました。さらに、CentOS Linux 8のサポートは2029年5月31日から2021年12月31日まで短縮されました。"
+
+  "homepage": {
+    "landing": {
+      "p1": {
+        "heading": "Rocky Linux",
+        "content": "コミュニティ主導の、商用環境にも本番環境にも対応したLinux。"
+      },
+      "p2": {
+        "heading": "Rocky Linux Projectとは？",
+        "content": "Rocky Linux は、ダウンストリームパートナーが方向転換した今、アメリカのトップエンタープライズ Linux ディストリビューションとの間で、バグをも含めて 100% の互換性を持つように設計されたコミュニティ商用OSです。このオペレーティングシステムはコミュニティ主導で開発されています。Rocky LinuxはCentOSプロジェクトの創設者であるGregory Kurtzer(グレゴリー・クルツァー)氏が率いています。現時点でのリリースは未定です。プロジェクトに貢献する場合は、このサイトに記載されている連絡手段で連絡を取ってください。"
+      }
     },
-    "q": {
-      "come-in": "Rocky Linux はどのような役割を持つのですか？",
-      "downstream-partner-direction": "\"ダウンストリームパートナーが方向転換した\"ってどういうこと？"
-    },
-    "title": "よくある質問"
+    "faq": {
+      "title": "よくある質問",
+      "a": {
+        "come-in": "Rocky Linuxは、以前にCentOSが行っていたように、リリースが追加される前ではなく、アップストリームベンダによって追加された後にリリースをビルドすることで、ダウンストリームビルドとして機能することを目指しています。",
+        "downstream-partner-direction": "CentOSプロジェクトは最近、CentOSの戦略の転換を発表しました。これまでCentOSは、アップストリームベンダーのダウンストリームビルドとして存在していたのに対し（アップストリームベンダーがパッチを適用した後にパッチ適用やアップデートを行う）、アップストリームビルド（アップストリームベンダーに組み込む前にパッチやアップデートをテストする）に移行するとしました。さらに、CentOS Linux 8のサポートは2029年5月31日から2021年12月31日まで短縮されました。"
+      },
+      "q": {
+        "come-in": "Rocky Linux はどのような役割を持つのですか？",
+        "downstream-partner-direction": "\"ダウンストリームパートナーが方向転換した\"ってどういうこと？"
+      }
+    }
   },
-  "landing": {
+
+  "download": {
     "p1": {
-      "content": "コミュニティ主導の、商用環境にも本番環境にも対応したLinux。",
-      "heading": "Rocky Linux"
+      "heading": "Downloads",
+      "content": "Download the official release of Rocky Linux from one of our trusted mirrors."
+    },
+    "warning": "The release you can download here is a <i>Release Candidate</i> and should not be used in production. Please check our <a class=\"underline font-medium\" href=\"/faq/\">FAQ</a> for more information.",
+    "table": {
+      "architecture": "Architecture",
+      "iso": "ISOS",
+      "isos": {
+        "minimal": "Minimal",
+        "dvd": "DVD",
+        "boot": "Boot",
+        "checksum": "Checksum"
+      },
+      "packages": "Packages"
     },
     "p2": {
-      "content": "Rocky Linux は、ダウンストリームパートナーが方向転換した今、アメリカのトップエンタープライズ Linux ディストリビューションとの間で、バグをも含めて 100% の互換性を持つように設計されたコミュニティ商用OSです。このオペレーティングシステムはコミュニティ主導で開発されています。Rocky LinuxはCentOSプロジェクトの創設者であるGregory Kurtzer(グレゴリー・クルツァー)氏が率いています。現時点でのリリースは未定です。プロジェクトに貢献する場合は、このサイトに記載されている連絡手段で連絡を取ってください。",
-      "heading": "Rocky Linux Projectとは？"
+      "content": "As you download and use Rocky Linux, the Rocky Enterprise Software Foundation invites you to <a class=\"text-green-600 dark:text-green-500 font-medium\" href=\"https://chat.rockylinux.org/\">be a part of the community as a contributor</a>. There are many ways to contribute to the project, from documentation, QA, and testing to coding changes for SIGs, providing mirroring or hosting, and helping other users."
     }
   },
+
   "lang": {
     "footer": {
       "choose-language": "言語を選択してください..."
     }
   },
-  "links": {
-    "close-menu": "メニューを閉じる",
-    "documentation": "ドキュメント",
-    "get-in-touch": "お問い合わせ",
-    "get-involved": "参加する",
-    "go-home": "ホームに戻る",
-    "join-the-discussion": "議論に参加する",
-    "posts": "News",
-    "show-your-interest": "Show Your Interest",
-    "sponsors": "Sponsors",
-    "donate": "Donate",
-    "store": "Store",
-    "press": "Press"
+
+  "errors": {
+    "404": {
+      "title": "Page not found.",
+      "explanation": "指定されたURLが見つかりませんでした。もう一度お試しください。"
+    }
   },
-  "socials": {
-    "forums": "Forums",
-    "github": "Github",
-    "reddit": "Reddit",
-    "mattermost": "Mattermost",
-    "twitter": "Twitter"
-  },
+
   "news": {
     "title": "News",
     "description": "Stay up-to-date on the latest from The Rocky Linux Project."
   },
+
   "press": {
     "title": "Press",
     "description": "See the latest about Rocky in the press."
   },
+
   "sponsors": {
     "title": "Sponsors",
-    "description": "We would like to thank our sponsors for their support thus far on the project."
+    "description": "We would like to thank our sponsors for their support thus far on the project.",
+    "tag": {
+      "fsponsor": "Founding Sponsor",
+      "psponsor": "Principal Sponsor"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "45drives": {
+        "name": "45Drives",
+        "description": "45Drives offers enterprise storage solutions built on powerful & robust open-source software that allows customers to benefit from the cost savings & flexibility of off-the-shelf hardware. Check them out for a fully supported data storage solution at the best cost per terabyte!"
+      },
+      "opendrives": {
+        "name": "OpenDrives",
+        "description": "OpenDrives is a global provider of enterprise-grade, hyper-scalable, network-attached-storage (NAS) solutions. We deliver the highest performing solutions for our customers - to match individual performance needs - for the most robust, complex and mission-critical projects and workflows, on-premises and into the cloud."
+      },
+      "montavista": {
+        "name": "MontaVista",
+        "description": "MontaVista Software is the leader in embedded commercial Linux, supporting MontaVista CGX, Yocto Project®, CentOS and Rocky Linux. MontaVista offers Open Source Software expertise, commercial-quality Linux distros, cost-effective maintenance and support for 10+ year life-cycles."
+      },
+      "aws": {
+        "name": "Amazon Web Services",
+        "description": "The RESF utilizes AWS to run much of the underlying infrastructure critical to the development and deployment of the services supporting Rocky Linux. From Koji builders for x86_64 and aarch64 running in EC2 to SRPM blob storage in S3, AWS is foundational to much of what we do."
+      }
+    }
+  },
+
+  "partners": {
+    "title": "Partners",
+    "description": "Partners of the RESF represent ongoing relationships of strategic importance to the Rocky Linux project. Through dedication of engineering expertise, infrastructure resources, or other means, their support is critical to our continued success and long term stability.",
+    "tag": {
+      "fpartner": "Founding Partner",
+      "ppartner": "Principal Partner"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "navercloud": {
+        "name": "NAVER Cloud",
+        "description": "NAVER Cloud Platform is a South Korean cloud service that started in 2017 under NAVER Cloud, a subsidiary of NAVER. It provides over 170 individual services in 2021 and holds various security certifications including CSA STAR GOLD, GDPR, and more. It also currently provides cloud services in 10 locations around the world."
+      },
+      "mattermost": {
+        "name": "Mattermost",
+        "description": "Mattermost is an open source messaging solution made for organizations with the highest security requirements. As big believers in the power of open source, Mattermost is thrilled to partner with RESF to help bring an enterprise-grade distribution of Linux to the tech community."
+      }
+    }
+  },
+
+  "faq": {
+    "heading": "Frequently Asked Questions",
+    "q1": {
+      "q": "Where can I download the release candidate?",
+      "a": "https://rockylinux.org/download"
+    },
+    "q2": {
+      "q": "What is a release candidate?",
+      "a": "A release candidate is a beta version of a product that has the potential to be stable.The intent of a release candidate is for the community to test and validate expected functionality of Rocky Linux and report any bugs if present."
+    },
+    "q3": {
+      "q": "Can I use the release candidate in production?",
+      "a": "Under no circumstance should you use a release candidate in a production environment. A release candidate is provided for testing and validation purposes only."
+    },
+    "q4": {
+      "q": "How can I help mirror the release candidate and future Rocky Linux releases?",
+      "a": "Please email <a href=\"mailto:mirrors@rockylinux.org\">mirrors@rockylinux.org</a> to express your interest."
+    },
+    "q5": {
+      "q": "I encountered a bug while testing the release candidate, what can I do?",
+      "a": "First, create an account using <a href=\"https://accounts.rockylinux.org/\"> Rocky Linux Account Services </a> , then head over to our <a href=\"https://bugs.rockylinux.org/\">Bugzilla server</a> to report any bugs."
+    },
+    "q6": {
+      "q": "How can I get involved with the Testing team?",
+      "a": "Please join the <a href=\"https://chat.rockylinux.org/rocky-linux/channels/testing\"> ~Testing </a> channel on our Mattermost server to get started. There’s also a testing topic on the forums for more durable conversation."
+    },
+    "q7": {
+      "q": "Where can I find the latest news about Rocky Linux?",
+      "a": "Stay tuned to our website, Twitter, LinkedIn, forums, and other platforms listed in our link directory for the latest announcements."
+    },
+    "q8": {
+      "q": "If Rocky Linux is just a respin of RHEL, what took so long for a release candidate?",
+      "a1": "If our only goal for Rocky Linux was to debrand and repackage RHEL, we would have been done much sooner. However, what we had to do differently is figure out how we could keep Rocky Linux in the hands of the community. Carefully devising this strategy ensures that Rocky Linux will never meet the same fate of CentOS.",
+      "a2": "The goal was not just to create a community managed RPM based distribution of Linux, but to ensure that it will remain freely available and always in the control of the community, much like Linux itself has. To do that required more than a build infrastructure; it required that we put in place the foundational structures that enable the community, ensuring that Rocky Linux is forever inclusive, free, and open. The infrastructure is built from the ground up by many collaborators and sponsoring organizations around composability and security compliance, providing the substrate for not only the base operating system but also an entire community of diverse interests to take part in the project."
+    },
+    "q9": {
+      "q": "If you’re not just repackaging RHEL, then what exactly are you doing?",
+      "a": "Our goal is to maintain Rocky Linux as a community-oriented distribution <i>by</i> the community, <i>for</i> the community. To do this, we are establishing the necessary organizational structures to ensure that Rocky Linux remains in the hands of the community. We want to make sure that it’s not possible for what happened to CentOS to happen to Rocky Linux."
+    },
+    "q10": {
+      "q": "How will you ensure that Rocky Linux truly remains a community enterprise operating system?",
+      "a": "First, we’ve taken steps to legally protect the Rocky Linux name. This means registering its trademarks and various associated properties to protect them from being controlled by another entity. We’ve achieved this by establishing them under the Rocky Enterprise Software Foundation (RESF). Next, we’re drafting a community charter that will define the organizational structure, objectives, values, and mission behind the legal entity that represents Rocky Linux. Critical in this charter is the establishment of principles that enable and protect the community: transparency, community involvement, open development, and independence. <strong> Rocky Linux will never be controlled, purchased, or otherwise influenced by a single entity or organization. </strong> Finally, we’re architecting and deploying the necessary infrastructure to further enable the community to contribute to Rocky Linux."
+    },
+    "q11": {
+      "q": "What infrastructure is necessary to enable the community?",
+      "a1": "We’ve established a number of teams to support the various efforts associated with developing Rocky Linux:",
+      "a2": "You can read more about this structure when it’s soon published. In order to enable collaboration across and within those teams, we needed to deploy our own chat infrastructure, forums, and website. Additionally, we’re also creating our build infrastructure, which will facilitate the development of the core operating system.",
+      "list": {
+        "community": "Community",
+        "core-inf": "Core Infrastructure",
+        "design": "Design",
+        "documentation": "Documentation",
+        "installer": "Installer",
+        "leadership": "Leadership",
+        "pkg-autob": "Package Auto-Builders",
+        "packaging": "Packaging",
+        "security": "Security",
+        "sigs": "Special Interest Groups (SIGs)",
+        "web": "Web"
+      }
+    },
+    "q12": {
+      "q": "Why does it take so much time to stand up a community and build infrastructure?",
+      "a": "It’s not terribly difficult to deploy a website, forums, or a build infrastructure in a reliable fashion. Our chat program for instance, which uses Mattermost, is distributed on a number of application servers behind a load balancer and was ready in just a couple of weeks. But it does require careful thought and planning to do it in a scalable and secure manner when you need to ensure vendor and platform agnosticity and long-term community involvement."
+    },
+    "q13": {
+      "q": "So what’s the short answer to all of this? What are some things you’re thinking about as you put Rocky Linux together?",
+      "a": "How do we carefully shepherd community trust? How do we ensure that anyone who wants to participate can not only do so immediately, but forever in the future as well? How do we engage and enable the community members who might not be as technical but want to contribute anyway? Solving for all of these challenges will take time, and we would love your help in doing so."
+    },
+    "q14": {
+      "q": "What if I have feedback or my question wasn’t answered here?",
+      "a": "Please email us: <a href=\"mailto:hello@rockylinux.org\">hello@rockylinux.org</a> and we’ll get back to you as soon as we can."
+    }
   }
 }

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -1,72 +1,241 @@
 {
   "language": "ko",
-  "copyright": {
-    "line1": "© 2021 The Rocky Linux Project. All rights reserved.",
-    "line2": "CentOS는 Red Hat, Inc.의 등록 상표입니다. Rocky Linux 프로젝트는 Red Hat, Inc.와 제휴하고 있지 않고, Red Hat, Inc.가 보증하지 않습니다."
-  },
-  "errors": {
-    "404": {
-      "explanation": "지정된 URL을 찾을 수 없습니다. 다시 시도해주세요.",
-      "title": "Page not found."
+
+  "global": {
+
+    "copyright": {
+      "line1": "© 2021 Rocky Enterprise Software Foundation. All rights reserved.",
+      "line2": "CentOS는 Red Hat, Inc.의 등록 상표입니다. Rocky Linux 프로젝트는 Red Hat, Inc.와 제휴하고 있지 않고, Red Hat, Inc.가 보증하지 않습니다."
+    },
+
+    "links": {
+      "close-menu": "메뉴 닫기",
+      "wiki": "Wiki",
+      "get-in-touch": "연락하기",
+      "get-involved": "참여하기",
+      "go-home": "처음으로",
+      "join-the-discussion": "논의에 참여하기",
+      "posts": "News",
+      "show-your-interest": "Show Your Interest",
+      "sponsors": "Sponsors",
+      "partners": "Partners",
+      "status": "Service Status",
+      "donate": "Donate",
+      "store": "Store",
+      "press": "Press",
+      "download": "Download",
+      "com_charter": "Community Charter",
+      "org_structure": "Organization Structure",
+      "privacy": "Privacy Policy",
+      "see-more": "See More",
+      "see-all": "See All",
+      "documentation": "문서",
+      "bug-report": "Report a bug"
+    },
+    "socials": {
+      "forums": "포럼",
+      "github": "Github",
+      "reddit": "Reddit",
+      "mattermost": "Mattermost",
+      "twitter": "Twitter"
     }
   },
-  "faq": {
-    "a": {
-      "come-in": "Rocky Linux는 이전에 CentOS가 해왔던 것처럼 다운스트림 빌드를 목표로 하며, 업스트림 벤더에 반영된 내용을 추가한 후에 출시됩니다.",
-      "downstream-partner-direction": "CentOS 프로젝트는 최근 CentOS에 대한 전략을 전환한다고 발표했습니다. 이전까지 CentOS는 업스트림 벤더의 다운스트림 빌드였지만(업스트림 벤더에서 완료한 패치와 업데이트를 반영) 업스트림 빌드로 전환할 것입니다(업스트림 벤더에 포함되기 전의 테스트 패치 및 업데이트를 반영). 또한 2029년 5월 31일까지였던 CentOS 8에 대한 지원 만료일이 2021년 12월 31일까지로 단축되었습니다."
+
+  "homepage": {
+    "landing": {
+      "p1": {
+        "heading": "Rocky Linux",
+        "content": "커뮤니티 중심의 기업을 위한 운영 환경을 지원하는 리눅스 배포판입니다."
+      },
+      "p2": {
+        "heading": "Rocky Linux 프로젝트가 뭐죠?",
+        "content": "다운스트림 파트너가 방향 전환을 한 지금에 있어서, Rocky Linux는 미국 최고의 엔터프라이즈 리눅스 배포판과 100% 호환성을 갖도록 설계된 커뮤니티 엔터프라이즈 운영 체제입니다. Rocky Linux는 커뮤니티에서 집중적으로 개발하고 있으며, CentOS 프로젝트의 창립자인 Gregory Kurtzer가 이를 이끌고 있습니다. 출시일은 미정이며, 기여자는 이 사이트에서 제공하는 커뮤니케이션 방법을 사용하여 연락해야 합니다."
+      }
     },
-    "q": {
-      "come-in": "Rocky Linux는 어떤 위치에 있는건가요?",
-      "downstream-partner-direction": "\"다운스트림 파트너가 방향을 전환했다\"가 무슨 말인가요?"
-    },
-    "title": "자주하는 질문들"
+    "faq": {
+      "title": "자주하는 질문들",
+      "a": {
+        "come-in": "Rocky Linux는 이전에 CentOS가 해왔던 것처럼 다운스트림 빌드를 목표로 하며, 업스트림 벤더에 반영된 내용을 추가한 후에 출시됩니다.",
+        "downstream-partner-direction": "CentOS 프로젝트는 최근 CentOS에 대한 전략을 전환한다고 발표했습니다. 이전까지 CentOS는 업스트림 벤더의 다운스트림 빌드였지만(업스트림 벤더에서 완료한 패치와 업데이트를 반영) 업스트림 빌드로 전환할 것입니다(업스트림 벤더에 포함되기 전의 테스트 패치 및 업데이트를 반영). 또한 2029년 5월 31일까지였던 CentOS 8에 대한 지원 만료일이 2021년 12월 31일까지로 단축되었습니다."
+      },
+      "q": {
+        "come-in": "Rocky Linux는 어떤 위치에 있는건가요?",
+        "downstream-partner-direction": "\"다운스트림 파트너가 방향을 전환했다\"가 무슨 말인가요?"
+      }
+    }
   },
-  "landing": {
+
+  "download": {
     "p1": {
-      "content": "커뮤니티 중심의 기업을 위한 운영 환경을 지원하는 리눅스 배포판입니다.",
-      "heading": "Rocky Linux"
+      "heading": "Downloads",
+      "content": "Download the official release of Rocky Linux from one of our trusted mirrors."
+    },
+    "warning": "The release you can download here is a <i>Release Candidate</i> and should not be used in production. Please check our <a class=\"underline font-medium\" href=\"/faq/\">FAQ</a> for more information.",
+    "table": {
+      "architecture": "Architecture",
+      "iso": "ISOS",
+      "isos": {
+        "minimal": "Minimal",
+        "dvd": "DVD",
+        "boot": "Boot",
+        "checksum": "Checksum"
+      },
+      "packages": "Packages"
     },
     "p2": {
-      "content": "다운스트림 파트너가 방향 전환을 한 지금에 있어서, Rocky Linux는 미국 최고의 엔터프라이즈 리눅스 배포판과 100% 호환성을 갖도록 설계된 커뮤니티 엔터프라이즈 운영 체제입니다. Rocky Linux는 커뮤니티에서 집중적으로 개발하고 있으며, CentOS 프로젝트의 창립자인 Gregory Kurtzer가 이를 이끌고 있습니다. 출시일은 미정이며, 기여자는 이 사이트에서 제공하는 커뮤니케이션 방법을 사용하여 연락해야 합니다.",
-      "heading": "Rocky Linux 프로젝트가 뭐죠?"
+      "content": "As you download and use Rocky Linux, the Rocky Enterprise Software Foundation invites you to <a class=\"text-green-600 dark:text-green-500 font-medium\" href=\"https://chat.rockylinux.org/\">be a part of the community as a contributor</a>. There are many ways to contribute to the project, from documentation, QA, and testing to coding changes for SIGs, providing mirroring or hosting, and helping other users."
     }
   },
+
   "lang": {
     "footer": {
       "choose-language": "언어를 선택하세요..."
     }
   },
-  "links": {
-    "close-menu": "메뉴 닫기",
-    "documentation": "문서",
-    "get-in-touch": "연락하기",
-    "get-involved": "참여하기",
-    "go-home": "처음으로",
-    "join-the-discussion": "논의에 참여하기",
-    "posts": "News",
-    "show-your-interest": "Show Your Interest",
-    "sponsors": "Sponsors",
-    "donate": "Donate",
-    "store": "Store",
-    "press": "Press"
+
+  "errors": {
+    "404": {
+      "title": "Page not found.",
+      "explanation": "지정된 URL을 찾을 수 없습니다. 다시 시도해주세요."
+    }
   },
-  "socials": {
-    "forums": "포럼",
-    "github": "Github",
-    "reddit": "Reddit",
-    "mattermost": "Mattermost",
-    "twitter": "Twitter"
-  },
+
   "news": {
     "title": "News",
     "description": "Stay up-to-date on the latest from The Rocky Linux Project."
   },
+
   "press": {
     "title": "Press",
     "description": "See the latest about Rocky in the press."
   },
+
   "sponsors": {
     "title": "Sponsors",
-    "description": "We would like to thank our sponsors for their support thus far on the project."
+    "description": "We would like to thank our sponsors for their support thus far on the project.",
+    "tag": {
+      "fsponsor": "Founding Sponsor",
+      "psponsor": "Principal Sponsor"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "45drives": {
+        "name": "45Drives",
+        "description": "45Drives offers enterprise storage solutions built on powerful & robust open-source software that allows customers to benefit from the cost savings & flexibility of off-the-shelf hardware. Check them out for a fully supported data storage solution at the best cost per terabyte!"
+      },
+      "opendrives": {
+        "name": "OpenDrives",
+        "description": "OpenDrives is a global provider of enterprise-grade, hyper-scalable, network-attached-storage (NAS) solutions. We deliver the highest performing solutions for our customers - to match individual performance needs - for the most robust, complex and mission-critical projects and workflows, on-premises and into the cloud."
+      },
+      "montavista": {
+        "name": "MontaVista",
+        "description": "MontaVista Software is the leader in embedded commercial Linux, supporting MontaVista CGX, Yocto Project®, CentOS and Rocky Linux. MontaVista offers Open Source Software expertise, commercial-quality Linux distros, cost-effective maintenance and support for 10+ year life-cycles."
+      },
+      "aws": {
+        "name": "Amazon Web Services",
+        "description": "The RESF utilizes AWS to run much of the underlying infrastructure critical to the development and deployment of the services supporting Rocky Linux. From Koji builders for x86_64 and aarch64 running in EC2 to SRPM blob storage in S3, AWS is foundational to much of what we do."
+      }
+    }
+  },
+
+  "partners": {
+    "title": "Partners",
+    "description": "Partners of the RESF represent ongoing relationships of strategic importance to the Rocky Linux project. Through dedication of engineering expertise, infrastructure resources, or other means, their support is critical to our continued success and long term stability.",
+    "tag": {
+      "fpartner": "Founding Partner",
+      "ppartner": "Principal Partner"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "navercloud": {
+        "name": "NAVER Cloud",
+        "description": "NAVER Cloud Platform is a South Korean cloud service that started in 2017 under NAVER Cloud, a subsidiary of NAVER. It provides over 170 individual services in 2021 and holds various security certifications including CSA STAR GOLD, GDPR, and more. It also currently provides cloud services in 10 locations around the world."
+      },
+      "mattermost": {
+        "name": "Mattermost",
+        "description": "Mattermost is an open source messaging solution made for organizations with the highest security requirements. As big believers in the power of open source, Mattermost is thrilled to partner with RESF to help bring an enterprise-grade distribution of Linux to the tech community."
+      }
+    }
+  },
+
+  "faq": {
+    "heading": "Frequently Asked Questions",
+    "q1": {
+      "q": "Where can I download the release candidate?",
+      "a": "https://rockylinux.org/download"
+    },
+    "q2": {
+      "q": "What is a release candidate?",
+      "a": "A release candidate is a beta version of a product that has the potential to be stable.The intent of a release candidate is for the community to test and validate expected functionality of Rocky Linux and report any bugs if present."
+    },
+    "q3": {
+      "q": "Can I use the release candidate in production?",
+      "a": "Under no circumstance should you use a release candidate in a production environment. A release candidate is provided for testing and validation purposes only."
+    },
+    "q4": {
+      "q": "How can I help mirror the release candidate and future Rocky Linux releases?",
+      "a": "Please email <a href=\"mailto:mirrors@rockylinux.org\">mirrors@rockylinux.org</a> to express your interest."
+    },
+    "q5": {
+      "q": "I encountered a bug while testing the release candidate, what can I do?",
+      "a": "First, create an account using <a href=\"https://accounts.rockylinux.org/\"> Rocky Linux Account Services </a> , then head over to our <a href=\"https://bugs.rockylinux.org/\">Bugzilla server</a> to report any bugs."
+    },
+    "q6": {
+      "q": "How can I get involved with the Testing team?",
+      "a": "Please join the <a href=\"https://chat.rockylinux.org/rocky-linux/channels/testing\"> ~Testing </a> channel on our Mattermost server to get started. There’s also a testing topic on the forums for more durable conversation."
+    },
+    "q7": {
+      "q": "Where can I find the latest news about Rocky Linux?",
+      "a": "Stay tuned to our website, Twitter, LinkedIn, forums, and other platforms listed in our link directory for the latest announcements."
+    },
+    "q8": {
+      "q": "If Rocky Linux is just a respin of RHEL, what took so long for a release candidate?",
+      "a1": "If our only goal for Rocky Linux was to debrand and repackage RHEL, we would have been done much sooner. However, what we had to do differently is figure out how we could keep Rocky Linux in the hands of the community. Carefully devising this strategy ensures that Rocky Linux will never meet the same fate of CentOS.",
+      "a2": "The goal was not just to create a community managed RPM based distribution of Linux, but to ensure that it will remain freely available and always in the control of the community, much like Linux itself has. To do that required more than a build infrastructure; it required that we put in place the foundational structures that enable the community, ensuring that Rocky Linux is forever inclusive, free, and open. The infrastructure is built from the ground up by many collaborators and sponsoring organizations around composability and security compliance, providing the substrate for not only the base operating system but also an entire community of diverse interests to take part in the project."
+    },
+    "q9": {
+      "q": "If you’re not just repackaging RHEL, then what exactly are you doing?",
+      "a": "Our goal is to maintain Rocky Linux as a community-oriented distribution <i>by</i> the community, <i>for</i> the community. To do this, we are establishing the necessary organizational structures to ensure that Rocky Linux remains in the hands of the community. We want to make sure that it’s not possible for what happened to CentOS to happen to Rocky Linux."
+    },
+    "q10": {
+      "q": "How will you ensure that Rocky Linux truly remains a community enterprise operating system?",
+      "a": "First, we’ve taken steps to legally protect the Rocky Linux name. This means registering its trademarks and various associated properties to protect them from being controlled by another entity. We’ve achieved this by establishing them under the Rocky Enterprise Software Foundation (RESF). Next, we’re drafting a community charter that will define the organizational structure, objectives, values, and mission behind the legal entity that represents Rocky Linux. Critical in this charter is the establishment of principles that enable and protect the community: transparency, community involvement, open development, and independence. <strong> Rocky Linux will never be controlled, purchased, or otherwise influenced by a single entity or organization. </strong> Finally, we’re architecting and deploying the necessary infrastructure to further enable the community to contribute to Rocky Linux."
+    },
+    "q11": {
+      "q": "What infrastructure is necessary to enable the community?",
+      "a1": "We’ve established a number of teams to support the various efforts associated with developing Rocky Linux:",
+      "a2": "You can read more about this structure when it’s soon published. In order to enable collaboration across and within those teams, we needed to deploy our own chat infrastructure, forums, and website. Additionally, we’re also creating our build infrastructure, which will facilitate the development of the core operating system.",
+      "list": {
+        "community": "Community",
+        "core-inf": "Core Infrastructure",
+        "design": "Design",
+        "documentation": "Documentation",
+        "installer": "Installer",
+        "leadership": "Leadership",
+        "pkg-autob": "Package Auto-Builders",
+        "packaging": "Packaging",
+        "security": "Security",
+        "sigs": "Special Interest Groups (SIGs)",
+        "web": "Web"
+      }
+    },
+    "q12": {
+      "q": "Why does it take so much time to stand up a community and build infrastructure?",
+      "a": "It’s not terribly difficult to deploy a website, forums, or a build infrastructure in a reliable fashion. Our chat program for instance, which uses Mattermost, is distributed on a number of application servers behind a load balancer and was ready in just a couple of weeks. But it does require careful thought and planning to do it in a scalable and secure manner when you need to ensure vendor and platform agnosticity and long-term community involvement."
+    },
+    "q13": {
+      "q": "So what’s the short answer to all of this? What are some things you’re thinking about as you put Rocky Linux together?",
+      "a": "How do we carefully shepherd community trust? How do we ensure that anyone who wants to participate can not only do so immediately, but forever in the future as well? How do we engage and enable the community members who might not be as technical but want to contribute anyway? Solving for all of these challenges will take time, and we would love your help in doing so."
+    },
+    "q14": {
+      "q": "What if I have feedback or my question wasn’t answered here?",
+      "a": "Please email us: <a href=\"mailto:hello@rockylinux.org\">hello@rockylinux.org</a> and we’ll get back to you as soon as we can."
+    }
   }
 }

--- a/src/i18n/locales/lv/translation.json
+++ b/src/i18n/locales/lv/translation.json
@@ -1,73 +1,241 @@
 {
   "language": "lv",
-  "copyright": {
-    "line1": "© 2021 The Rocky Linux Project. Visas tiesībais aizsargātas.",
-    "line2": "CentOS ir Red Hat, Inc reģistrēta preču zīme. Rocky Linux Project nav saistīts un nav atbalstīts no Red Hat, Inc."
-  },
-  "errors": {
-    "404": {
-      "explanation": "Pieprasītā vietne nav atrasta. Lūdzu, mēģini vēlreiz.",
-      "title": "Lapa nav atrasta."
+
+  "global": {
+
+    "copyright": {
+      "line1": "© 2021 The Rocky Linux Project. Visas tiesībais aizsargātas.",
+      "line2": "CentOS ir Red Hat, Inc reģistrēta preču zīme. Rocky Linux Project nav saistīts un nav atbalstīts no Red Hat, Inc."
+    },
+
+    "links": {
+      "close-menu": "Aizvērt izvēlni",
+      "wiki": "Wiki",
+      "get-in-touch": "Saziņai",
+      "get-involved": "Iesaisties",
+      "go-home": "Mājup",
+      "join-the-discussion": "Pievienojies diskusijai",
+      "posts": "News",
+      "show-your-interest": "Show Your Interest",
+      "sponsors": "Sponsors",
+      "partners": "Partners",
+      "status": "Service Status",
+      "donate": "Donate",
+      "store": "Store",
+      "press": "Press",
+      "download": "Download",
+      "com_charter": "Community Charter",
+      "org_structure": "Organization Structure",
+      "privacy": "Privacy Policy",
+      "see-more": "See More",
+      "see-all": "See All",
+      "documentation": "Dokumentācija",
+      "bug-report": "Report a bug"
+    },
+    "socials": {
+      "forums": "Forums",
+      "github": "Github",
+      "reddit": "Reddit",
+      "mattermost": "Mattermost",
+      "twitter": "Twitter"
     }
   },
-  "faq": {
-    "a": {
-      "come-in": "Rocky Linux ir izveidots ar mērķi turpināt piedāvāt Linux distribūciju kas veidota pēc atjauninājumu iekļaušanas partnera distribūcijā, salīdzināmi kā tas notika pirms CentOS izstrādes virziena maiņas.",
-      "downstream-partner-direction": "CentOS projekts nesen paziņoja par stratēģisku virziena maiņu CentOS projekta izstrādē. Agrāk CentOS distribūcija eksistēja kā būvējums veidots no partnera izejas koda - saņemot labojumus un atjauninājums pēc partnera distribūcijas. Turpmāk CentOS distribūcija saņems atjauninājumus pirms partnera distribūcijas, testējot atjauninājumus un labojumus pirms to iekļaušanas distribūcījā. Papildus tam, CentOS 8. versijas atbalsta laiks tika saīsināts no 2029. gada 31. maija līdz 2021. gada 31. decembrim."
+
+  "homepage": {
+    "landing": {
+      "p1": {
+        "heading": "Rocky Linux",
+        "content": "Komūnas iniciatīva biznesa klases produkcijas Linux operetājsistēmas izveidē"
+      },
+      "p2": {
+        "heading": "Kas ir Rocky Linux?",
+        "content": "Rocky Linux ir komūnas veidota biznesa klases operētājsistēma, veidota būt 100% savietojama ar Amerikas vislabāk pazīstamo biznesa Linux distribūciju, sekojot tās veidotāj-partnera virziena maiņai. Rocky Linux distributīvu aktīvi istrāda komūna, tās izstrādi vada Gregorijs Kurtzers, CentOS projekta dibinātājs. Distribūcijas iznākšanas datums nav zināms. Visi kas vēlas iesaistīties Rocky Linux izveidē tiek aicināti sazināties ar mums izmantojot kādu no šajā vietnē piedāvātajām iespējām."
+      }
     },
-    "q": {
-      "come-in": "Ko piedāvā Rocky Linux?",
-      "downstream-partner-direction": "Kas tiek domāts ar , \"sekojot tās partnera virziena maiņai\"?"
-    },
-    "title": "Biežāk Uzdotie Jautājumi"
+    "faq": {
+      "title": "Biežāk Uzdotie Jautājumi",
+      "a": {
+        "come-in": "Rocky Linux ir izveidots ar mērķi turpināt piedāvāt Linux distribūciju kas veidota pēc atjauninājumu iekļaušanas partnera distribūcijā, salīdzināmi kā tas notika pirms CentOS izstrādes virziena maiņas.",
+        "downstream-partner-direction": "CentOS projekts nesen paziņoja par stratēģisku virziena maiņu CentOS projekta izstrādē. Agrāk CentOS distribūcija eksistēja kā būvējums veidots no partnera izejas koda - saņemot labojumus un atjauninājums pēc partnera distribūcijas. Turpmāk CentOS distribūcija saņems atjauninājumus pirms partnera distribūcijas, testējot atjauninājumus un labojumus pirms to iekļaušanas distribūcījā. Papildus tam, CentOS 8. versijas atbalsta laiks tika saīsināts no 2029. gada 31. maija līdz 2021. gada 31. decembrim."
+      },
+      "q": {
+        "come-in": "Ko piedāvā Rocky Linux?",
+        "downstream-partner-direction": "Kas tiek domāts ar , \"sekojot tās partnera virziena maiņai\"?"
+      }
+    }
   },
-  "landing": {
+
+  "download": {
     "p1": {
-      "content": "Komūnas iniciatīva biznesa klases produkcijas Linux operetājsistēmas izveidē",
-      "heading": "Rocky Linux"
+      "heading": "Downloads",
+      "content": "Download the official release of Rocky Linux from one of our trusted mirrors."
+    },
+    "warning": "The release you can download here is a <i>Release Candidate</i> and should not be used in production. Please check our <a class=\"underline font-medium\" href=\"/faq/\">FAQ</a> for more information.",
+    "table": {
+      "architecture": "Architecture",
+      "iso": "ISOS",
+      "isos": {
+        "minimal": "Minimal",
+        "dvd": "DVD",
+        "boot": "Boot",
+        "checksum": "Checksum"
+      },
+      "packages": "Packages"
     },
     "p2": {
-      "content": "Rocky Linux ir komūnas veidota biznesa klases operētājsistēma, veidota būt 100% savietojama ar Amerikas vislabāk pazīstamo biznesa Linux distribūciju, sekojot tās veidotāj-partnera virziena maiņai. Rocky Linux distributīvu aktīvi istrāda komūna, tās izstrādi vada Gregorijs Kurtzers, CentOS projekta dibinātājs. Distribūcijas iznākšanas datums nav zināms. Visi kas vēlas iesaistīties Rocky Linux izveidē tiek aicināti sazināties ar mums izmantojot kādu no šajā vietnē piedāvātajām iespējām.",
-      "heading": "Kas ir Rocky Linux?"
+      "content": "As you download and use Rocky Linux, the Rocky Enterprise Software Foundation invites you to <a class=\"text-green-600 dark:text-green-500 font-medium\" href=\"https://chat.rockylinux.org/\">be a part of the community as a contributor</a>. There are many ways to contribute to the project, from documentation, QA, and testing to coding changes for SIGs, providing mirroring or hosting, and helping other users."
     }
   },
+
   "lang": {
     "footer": {
-      "choose-language": "Izvēlies valodu...",
-      "literal": "Valoda:"
+      "choose-language": "Izvēlies valodu..."
     }
   },
-  "links": {
-    "close-menu": "Aizvērt izvēlni",
-    "documentation": "Dokumentācija",
-    "get-in-touch": "Saziņai",
-    "get-involved": "Iesaisties",
-    "go-home": "Mājup",
-    "join-the-discussion": "Pievienojies diskusijai",
-    "posts": "News",
-    "show-your-interest": "Show Your Interest",
-    "sponsors": "Sponsors",
-    "donate": "Donate",
-    "store": "Store",
-    "press": "Press"
+
+  "errors": {
+    "404": {
+      "title": "Lapa nav atrasta.",
+      "explanation": "Pieprasītā vietne nav atrasta. Lūdzu, mēģini vēlreiz."
+    }
   },
-  "socials": {
-    "forums": "Forums",
-    "github": "GitHub",
-    "reddit": "Reddit",
-    "mattermost": "Mattermost",
-    "twitter": "Twitter"
-  },
+
   "news": {
     "title": "News",
     "description": "Stay up-to-date on the latest from The Rocky Linux Project."
   },
+
   "press": {
     "title": "Press",
     "description": "See the latest about Rocky in the press."
   },
+
   "sponsors": {
     "title": "Sponsors",
-    "description": "We would like to thank our sponsors for their support thus far on the project."
+    "description": "We would like to thank our sponsors for their support thus far on the project.",
+    "tag": {
+      "fsponsor": "Founding Sponsor",
+      "psponsor": "Principal Sponsor"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "45drives": {
+        "name": "45Drives",
+        "description": "45Drives offers enterprise storage solutions built on powerful & robust open-source software that allows customers to benefit from the cost savings & flexibility of off-the-shelf hardware. Check them out for a fully supported data storage solution at the best cost per terabyte!"
+      },
+      "opendrives": {
+        "name": "OpenDrives",
+        "description": "OpenDrives is a global provider of enterprise-grade, hyper-scalable, network-attached-storage (NAS) solutions. We deliver the highest performing solutions for our customers - to match individual performance needs - for the most robust, complex and mission-critical projects and workflows, on-premises and into the cloud."
+      },
+      "montavista": {
+        "name": "MontaVista",
+        "description": "MontaVista Software is the leader in embedded commercial Linux, supporting MontaVista CGX, Yocto Project®, CentOS and Rocky Linux. MontaVista offers Open Source Software expertise, commercial-quality Linux distros, cost-effective maintenance and support for 10+ year life-cycles."
+      },
+      "aws": {
+        "name": "Amazon Web Services",
+        "description": "The RESF utilizes AWS to run much of the underlying infrastructure critical to the development and deployment of the services supporting Rocky Linux. From Koji builders for x86_64 and aarch64 running in EC2 to SRPM blob storage in S3, AWS is foundational to much of what we do."
+      }
+    }
+  },
+
+  "partners": {
+    "title": "Partners",
+    "description": "Partners of the RESF represent ongoing relationships of strategic importance to the Rocky Linux project. Through dedication of engineering expertise, infrastructure resources, or other means, their support is critical to our continued success and long term stability.",
+    "tag": {
+      "fpartner": "Founding Partner",
+      "ppartner": "Principal Partner"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "navercloud": {
+        "name": "NAVER Cloud",
+        "description": "NAVER Cloud Platform is a South Korean cloud service that started in 2017 under NAVER Cloud, a subsidiary of NAVER. It provides over 170 individual services in 2021 and holds various security certifications including CSA STAR GOLD, GDPR, and more. It also currently provides cloud services in 10 locations around the world."
+      },
+      "mattermost": {
+        "name": "Mattermost",
+        "description": "Mattermost is an open source messaging solution made for organizations with the highest security requirements. As big believers in the power of open source, Mattermost is thrilled to partner with RESF to help bring an enterprise-grade distribution of Linux to the tech community."
+      }
+    }
+  },
+
+  "faq": {
+    "heading": "Frequently Asked Questions",
+    "q1": {
+      "q": "Where can I download the release candidate?",
+      "a": "https://rockylinux.org/download"
+    },
+    "q2": {
+      "q": "What is a release candidate?",
+      "a": "A release candidate is a beta version of a product that has the potential to be stable.The intent of a release candidate is for the community to test and validate expected functionality of Rocky Linux and report any bugs if present."
+    },
+    "q3": {
+      "q": "Can I use the release candidate in production?",
+      "a": "Under no circumstance should you use a release candidate in a production environment. A release candidate is provided for testing and validation purposes only."
+    },
+    "q4": {
+      "q": "How can I help mirror the release candidate and future Rocky Linux releases?",
+      "a": "Please email <a href=\"mailto:mirrors@rockylinux.org\">mirrors@rockylinux.org</a> to express your interest."
+    },
+    "q5": {
+      "q": "I encountered a bug while testing the release candidate, what can I do?",
+      "a": "First, create an account using <a href=\"https://accounts.rockylinux.org/\"> Rocky Linux Account Services </a> , then head over to our <a href=\"https://bugs.rockylinux.org/\">Bugzilla server</a> to report any bugs."
+    },
+    "q6": {
+      "q": "How can I get involved with the Testing team?",
+      "a": "Please join the <a href=\"https://chat.rockylinux.org/rocky-linux/channels/testing\"> ~Testing </a> channel on our Mattermost server to get started. There’s also a testing topic on the forums for more durable conversation."
+    },
+    "q7": {
+      "q": "Where can I find the latest news about Rocky Linux?",
+      "a": "Stay tuned to our website, Twitter, LinkedIn, forums, and other platforms listed in our link directory for the latest announcements."
+    },
+    "q8": {
+      "q": "If Rocky Linux is just a respin of RHEL, what took so long for a release candidate?",
+      "a1": "If our only goal for Rocky Linux was to debrand and repackage RHEL, we would have been done much sooner. However, what we had to do differently is figure out how we could keep Rocky Linux in the hands of the community. Carefully devising this strategy ensures that Rocky Linux will never meet the same fate of CentOS.",
+      "a2": "The goal was not just to create a community managed RPM based distribution of Linux, but to ensure that it will remain freely available and always in the control of the community, much like Linux itself has. To do that required more than a build infrastructure; it required that we put in place the foundational structures that enable the community, ensuring that Rocky Linux is forever inclusive, free, and open. The infrastructure is built from the ground up by many collaborators and sponsoring organizations around composability and security compliance, providing the substrate for not only the base operating system but also an entire community of diverse interests to take part in the project."
+    },
+    "q9": {
+      "q": "If you’re not just repackaging RHEL, then what exactly are you doing?",
+      "a": "Our goal is to maintain Rocky Linux as a community-oriented distribution <i>by</i> the community, <i>for</i> the community. To do this, we are establishing the necessary organizational structures to ensure that Rocky Linux remains in the hands of the community. We want to make sure that it’s not possible for what happened to CentOS to happen to Rocky Linux."
+    },
+    "q10": {
+      "q": "How will you ensure that Rocky Linux truly remains a community enterprise operating system?",
+      "a": "First, we’ve taken steps to legally protect the Rocky Linux name. This means registering its trademarks and various associated properties to protect them from being controlled by another entity. We’ve achieved this by establishing them under the Rocky Enterprise Software Foundation (RESF). Next, we’re drafting a community charter that will define the organizational structure, objectives, values, and mission behind the legal entity that represents Rocky Linux. Critical in this charter is the establishment of principles that enable and protect the community: transparency, community involvement, open development, and independence. <strong> Rocky Linux will never be controlled, purchased, or otherwise influenced by a single entity or organization. </strong> Finally, we’re architecting and deploying the necessary infrastructure to further enable the community to contribute to Rocky Linux."
+    },
+    "q11": {
+      "q": "What infrastructure is necessary to enable the community?",
+      "a1": "We’ve established a number of teams to support the various efforts associated with developing Rocky Linux:",
+      "a2": "You can read more about this structure when it’s soon published. In order to enable collaboration across and within those teams, we needed to deploy our own chat infrastructure, forums, and website. Additionally, we’re also creating our build infrastructure, which will facilitate the development of the core operating system.",
+      "list": {
+        "community": "Community",
+        "core-inf": "Core Infrastructure",
+        "design": "Design",
+        "documentation": "Documentation",
+        "installer": "Installer",
+        "leadership": "Leadership",
+        "pkg-autob": "Package Auto-Builders",
+        "packaging": "Packaging",
+        "security": "Security",
+        "sigs": "Special Interest Groups (SIGs)",
+        "web": "Web"
+      }
+    },
+    "q12": {
+      "q": "Why does it take so much time to stand up a community and build infrastructure?",
+      "a": "It’s not terribly difficult to deploy a website, forums, or a build infrastructure in a reliable fashion. Our chat program for instance, which uses Mattermost, is distributed on a number of application servers behind a load balancer and was ready in just a couple of weeks. But it does require careful thought and planning to do it in a scalable and secure manner when you need to ensure vendor and platform agnosticity and long-term community involvement."
+    },
+    "q13": {
+      "q": "So what’s the short answer to all of this? What are some things you’re thinking about as you put Rocky Linux together?",
+      "a": "How do we carefully shepherd community trust? How do we ensure that anyone who wants to participate can not only do so immediately, but forever in the future as well? How do we engage and enable the community members who might not be as technical but want to contribute anyway? Solving for all of these challenges will take time, and we would love your help in doing so."
+    },
+    "q14": {
+      "q": "What if I have feedback or my question wasn’t answered here?",
+      "a": "Please email us: <a href=\"mailto:hello@rockylinux.org\">hello@rockylinux.org</a> and we’ll get back to you as soon as we can."
+    }
   }
 }

--- a/src/i18n/locales/nb-no/translation.json
+++ b/src/i18n/locales/nb-no/translation.json
@@ -1,72 +1,241 @@
 {
   "language": "nb-NO",
-  "copyright": {
-    "line1": "© 2021 The Rocky Linux Project. Alle rettigheter reservert.",
-    "line2": "CentOS er et registrert varemerke som tilhører Red Hat, Inc. The Rocky Linux Project er ikke tilknyttet eller støttet av Red Hat, Inc."
-  },
-  "errors": {
-    "404": {
-      "explanation": "Forespurt ressurs kunne ikke bli funnet. Vennligst prøv igjen.",
-      "title": "Siden ble ikke funnet."
+
+  "global": {
+
+    "copyright": {
+      "line1": "© 2021 The Rocky Linux Project. Alle rettigheter reservert.",
+      "line2": "CentOS er et registrert varemerke som tilhører Red Hat, Inc. The Rocky Linux Project er ikke tilknyttet eller støttet av Red Hat, Inc."
+    },
+
+    "links": {
+      "close-menu": "Lukk meny",
+      "wiki": "Wiki",
+      "get-in-touch": "Ta kontakt",
+      "get-involved": "Bli involvert",
+      "go-home": "Hjem",
+      "join-the-discussion": "Bli med på diskusjonen",
+      "posts": "News",
+      "show-your-interest": "Show Your Interest",
+      "sponsors": "Sponsors",
+      "partners": "Partners",
+      "status": "Service Status",
+      "donate": "Donate",
+      "store": "Store",
+      "press": "Press",
+      "download": "Download",
+      "com_charter": "Community Charter",
+      "org_structure": "Organization Structure",
+      "privacy": "Privacy Policy",
+      "see-more": "See More",
+      "see-all": "See All",
+      "documentation": "Dokumentasjon",
+      "bug-report": "Report a bug"
+    },
+    "socials": {
+      "forums": "Forums",
+      "github": "Github",
+      "reddit": "Reddit",
+      "mattermost": "Mattermost",
+      "twitter": "Twitter"
     }
   },
-  "faq": {
-    "a": {
-      "come-in": "Rocky Linux ønsker å lanseres som et nedstrøms alternativ som CentOS gjorde tidligere, hvor endringer blir lagt til etter at leverandøren gjør dem tilgjengelig, ikke før.",
-      "downstream-partner-direction": "CentOS prosjektet har nylig annonsert at de bytter strategy for CentOS. Før ble CentOS lansert som et nedstrøms alternativ for dets oppstrøms leverandør (altså at CentOS mottok oppdateringer etter at leverandøren gjorde det), men bytter nå til et oppstrøms strategi (som betyr at oppdateringene vil bli testet på CentOS før det blir inkludert hos leverandøren). I tillegg blir støtten for CentOS Linux 8 kuttet fra 31. mai 2029 til 31. desember 2021."
+
+  "homepage": {
+    "landing": {
+      "p1": {
+        "heading": "Rocky Linux",
+        "content": "Er et samfunnsdrevet prosjekt som vil gi deg en produksjonsklar og næringslivsrettet Linux."
+      },
+      "p2": {
+        "heading": "Hva er Rocky Linux?",
+        "content": "Rocky Linux er et samfunnsdrevet næringslivsrettet operativ system designet for å være 100% feil-for-feil kompatibel med Amerikas topp næringslivsrettet Linux distribusjon nå som dets nedstrøms partner har byttet retning. Det er under utvikling av Rocky Linux samfunnet. Rocky Linux er ledet av Gregory Kurtzer, grunnlegger av CentOS prosjektet. Det er ingen estimat for en lansering. Bidragsytere er oppfordret til å nå oss via kommunikasjonsalternativene presentert på denne siden."
+      }
     },
-    "q": {
-      "come-in": "Så hvor kommer Rocky Linux inn?",
-      "downstream-partner-direction": "Hva menes det med \"dets nedstrøms partner har byttet retning\"?"
-    },
-    "title": "Ofte stilte spørsmål"
+    "faq": {
+      "title": "Ofte stilte spørsmål",
+      "a": {
+        "come-in": "Rocky Linux ønsker å lanseres som et nedstrøms alternativ som CentOS gjorde tidligere, hvor endringer blir lagt til etter at leverandøren gjør dem tilgjengelig, ikke før.",
+        "downstream-partner-direction": "CentOS prosjektet har nylig annonsert at de bytter strategy for CentOS. Før ble CentOS lansert som et nedstrøms alternativ for dets oppstrøms leverandør (altså at CentOS mottok oppdateringer etter at leverandøren gjorde det), men bytter nå til et oppstrøms strategi (som betyr at oppdateringene vil bli testet på CentOS før det blir inkludert hos leverandøren). I tillegg blir støtten for CentOS Linux 8 kuttet fra 31. mai 2029 til 31. desember 2021."
+      },
+      "q": {
+        "come-in": "Så hvor kommer Rocky Linux inn?",
+        "downstream-partner-direction": "Hva menes det med \"dets nedstrøms partner har byttet retning\"?"
+      }
+    }
   },
-  "landing": {
+
+  "download": {
     "p1": {
-      "content": "Er et samfunnsdrevet prosjekt som vil gi deg en produksjonsklar og næringslivsrettet Linux.",
-      "heading": "Rocky Linux"
+      "heading": "Downloads",
+      "content": "Download the official release of Rocky Linux from one of our trusted mirrors."
+    },
+    "warning": "The release you can download here is a <i>Release Candidate</i> and should not be used in production. Please check our <a class=\"underline font-medium\" href=\"/faq/\">FAQ</a> for more information.",
+    "table": {
+      "architecture": "Architecture",
+      "iso": "ISOS",
+      "isos": {
+        "minimal": "Minimal",
+        "dvd": "DVD",
+        "boot": "Boot",
+        "checksum": "Checksum"
+      },
+      "packages": "Packages"
     },
     "p2": {
-      "content": "Rocky Linux er et samfunnsdrevet næringslivsrettet operativ system designet for å være 100% feil-for-feil kompatibel med Amerikas topp næringslivsrettet Linux distribusjon nå som dets nedstrøms partner har byttet retning. Det er under utvikling av Rocky Linux samfunnet. Rocky Linux er ledet av Gregory Kurtzer, grunnlegger av CentOS prosjektet. Det er ingen estimat for en lansering. Bidragsytere er oppfordret til å nå oss via kommunikasjonsalternativene presentert på denne siden.",
-      "heading": "Hva er Rocky Linux?"
+      "content": "As you download and use Rocky Linux, the Rocky Enterprise Software Foundation invites you to <a class=\"text-green-600 dark:text-green-500 font-medium\" href=\"https://chat.rockylinux.org/\">be a part of the community as a contributor</a>. There are many ways to contribute to the project, from documentation, QA, and testing to coding changes for SIGs, providing mirroring or hosting, and helping other users."
     }
   },
+
   "lang": {
     "footer": {
       "choose-language": "Velg et språk..."
     }
   },
-  "links": {
-    "close-menu": "Lukk meny",
-    "documentation": "Dokumentasjon",
-    "get-in-touch": "Ta kontakt",
-    "get-involved": "Bli involvert",
-    "go-home": "Hjem",
-    "join-the-discussion": "Bli med på diskusjonen",
-    "posts": "News",
-    "show-your-interest": "Show Your Interest",
-    "sponsors": "Sponsors",
-    "donate": "Donate",
-    "store": "Store",
-    "press": "Press"
+
+  "errors": {
+    "404": {
+      "title": "Siden ble ikke funnet.",
+      "explanation": "Forespurt ressurs kunne ikke bli funnet. Vennligst prøv igjen."
+    }
   },
-  "socials": {
-    "forums": "Forum",
-    "github": "Github",
-    "reddit": "Reddit",
-    "mattermost": "Mattermost",
-    "twitter": "Twitter"
-  },
+
   "news": {
     "title": "News",
     "description": "Stay up-to-date on the latest from The Rocky Linux Project."
   },
+
   "press": {
     "title": "Press",
     "description": "See the latest about Rocky in the press."
   },
+
   "sponsors": {
     "title": "Sponsors",
-    "description": "We would like to thank our sponsors for their support thus far on the project."
+    "description": "We would like to thank our sponsors for their support thus far on the project.",
+    "tag": {
+      "fsponsor": "Founding Sponsor",
+      "psponsor": "Principal Sponsor"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "45drives": {
+        "name": "45Drives",
+        "description": "45Drives offers enterprise storage solutions built on powerful & robust open-source software that allows customers to benefit from the cost savings & flexibility of off-the-shelf hardware. Check them out for a fully supported data storage solution at the best cost per terabyte!"
+      },
+      "opendrives": {
+        "name": "OpenDrives",
+        "description": "OpenDrives is a global provider of enterprise-grade, hyper-scalable, network-attached-storage (NAS) solutions. We deliver the highest performing solutions for our customers - to match individual performance needs - for the most robust, complex and mission-critical projects and workflows, on-premises and into the cloud."
+      },
+      "montavista": {
+        "name": "MontaVista",
+        "description": "MontaVista Software is the leader in embedded commercial Linux, supporting MontaVista CGX, Yocto Project®, CentOS and Rocky Linux. MontaVista offers Open Source Software expertise, commercial-quality Linux distros, cost-effective maintenance and support for 10+ year life-cycles."
+      },
+      "aws": {
+        "name": "Amazon Web Services",
+        "description": "The RESF utilizes AWS to run much of the underlying infrastructure critical to the development and deployment of the services supporting Rocky Linux. From Koji builders for x86_64 and aarch64 running in EC2 to SRPM blob storage in S3, AWS is foundational to much of what we do."
+      }
+    }
+  },
+
+  "partners": {
+    "title": "Partners",
+    "description": "Partners of the RESF represent ongoing relationships of strategic importance to the Rocky Linux project. Through dedication of engineering expertise, infrastructure resources, or other means, their support is critical to our continued success and long term stability.",
+    "tag": {
+      "fpartner": "Founding Partner",
+      "ppartner": "Principal Partner"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "navercloud": {
+        "name": "NAVER Cloud",
+        "description": "NAVER Cloud Platform is a South Korean cloud service that started in 2017 under NAVER Cloud, a subsidiary of NAVER. It provides over 170 individual services in 2021 and holds various security certifications including CSA STAR GOLD, GDPR, and more. It also currently provides cloud services in 10 locations around the world."
+      },
+      "mattermost": {
+        "name": "Mattermost",
+        "description": "Mattermost is an open source messaging solution made for organizations with the highest security requirements. As big believers in the power of open source, Mattermost is thrilled to partner with RESF to help bring an enterprise-grade distribution of Linux to the tech community."
+      }
+    }
+  },
+
+  "faq": {
+    "heading": "Frequently Asked Questions",
+    "q1": {
+      "q": "Where can I download the release candidate?",
+      "a": "https://rockylinux.org/download"
+    },
+    "q2": {
+      "q": "What is a release candidate?",
+      "a": "A release candidate is a beta version of a product that has the potential to be stable.The intent of a release candidate is for the community to test and validate expected functionality of Rocky Linux and report any bugs if present."
+    },
+    "q3": {
+      "q": "Can I use the release candidate in production?",
+      "a": "Under no circumstance should you use a release candidate in a production environment. A release candidate is provided for testing and validation purposes only."
+    },
+    "q4": {
+      "q": "How can I help mirror the release candidate and future Rocky Linux releases?",
+      "a": "Please email <a href=\"mailto:mirrors@rockylinux.org\">mirrors@rockylinux.org</a> to express your interest."
+    },
+    "q5": {
+      "q": "I encountered a bug while testing the release candidate, what can I do?",
+      "a": "First, create an account using <a href=\"https://accounts.rockylinux.org/\"> Rocky Linux Account Services </a> , then head over to our <a href=\"https://bugs.rockylinux.org/\">Bugzilla server</a> to report any bugs."
+    },
+    "q6": {
+      "q": "How can I get involved with the Testing team?",
+      "a": "Please join the <a href=\"https://chat.rockylinux.org/rocky-linux/channels/testing\"> ~Testing </a> channel on our Mattermost server to get started. There’s also a testing topic on the forums for more durable conversation."
+    },
+    "q7": {
+      "q": "Where can I find the latest news about Rocky Linux?",
+      "a": "Stay tuned to our website, Twitter, LinkedIn, forums, and other platforms listed in our link directory for the latest announcements."
+    },
+    "q8": {
+      "q": "If Rocky Linux is just a respin of RHEL, what took so long for a release candidate?",
+      "a1": "If our only goal for Rocky Linux was to debrand and repackage RHEL, we would have been done much sooner. However, what we had to do differently is figure out how we could keep Rocky Linux in the hands of the community. Carefully devising this strategy ensures that Rocky Linux will never meet the same fate of CentOS.",
+      "a2": "The goal was not just to create a community managed RPM based distribution of Linux, but to ensure that it will remain freely available and always in the control of the community, much like Linux itself has. To do that required more than a build infrastructure; it required that we put in place the foundational structures that enable the community, ensuring that Rocky Linux is forever inclusive, free, and open. The infrastructure is built from the ground up by many collaborators and sponsoring organizations around composability and security compliance, providing the substrate for not only the base operating system but also an entire community of diverse interests to take part in the project."
+    },
+    "q9": {
+      "q": "If you’re not just repackaging RHEL, then what exactly are you doing?",
+      "a": "Our goal is to maintain Rocky Linux as a community-oriented distribution <i>by</i> the community, <i>for</i> the community. To do this, we are establishing the necessary organizational structures to ensure that Rocky Linux remains in the hands of the community. We want to make sure that it’s not possible for what happened to CentOS to happen to Rocky Linux."
+    },
+    "q10": {
+      "q": "How will you ensure that Rocky Linux truly remains a community enterprise operating system?",
+      "a": "First, we’ve taken steps to legally protect the Rocky Linux name. This means registering its trademarks and various associated properties to protect them from being controlled by another entity. We’ve achieved this by establishing them under the Rocky Enterprise Software Foundation (RESF). Next, we’re drafting a community charter that will define the organizational structure, objectives, values, and mission behind the legal entity that represents Rocky Linux. Critical in this charter is the establishment of principles that enable and protect the community: transparency, community involvement, open development, and independence. <strong> Rocky Linux will never be controlled, purchased, or otherwise influenced by a single entity or organization. </strong> Finally, we’re architecting and deploying the necessary infrastructure to further enable the community to contribute to Rocky Linux."
+    },
+    "q11": {
+      "q": "What infrastructure is necessary to enable the community?",
+      "a1": "We’ve established a number of teams to support the various efforts associated with developing Rocky Linux:",
+      "a2": "You can read more about this structure when it’s soon published. In order to enable collaboration across and within those teams, we needed to deploy our own chat infrastructure, forums, and website. Additionally, we’re also creating our build infrastructure, which will facilitate the development of the core operating system.",
+      "list": {
+        "community": "Community",
+        "core-inf": "Core Infrastructure",
+        "design": "Design",
+        "documentation": "Documentation",
+        "installer": "Installer",
+        "leadership": "Leadership",
+        "pkg-autob": "Package Auto-Builders",
+        "packaging": "Packaging",
+        "security": "Security",
+        "sigs": "Special Interest Groups (SIGs)",
+        "web": "Web"
+      }
+    },
+    "q12": {
+      "q": "Why does it take so much time to stand up a community and build infrastructure?",
+      "a": "It’s not terribly difficult to deploy a website, forums, or a build infrastructure in a reliable fashion. Our chat program for instance, which uses Mattermost, is distributed on a number of application servers behind a load balancer and was ready in just a couple of weeks. But it does require careful thought and planning to do it in a scalable and secure manner when you need to ensure vendor and platform agnosticity and long-term community involvement."
+    },
+    "q13": {
+      "q": "So what’s the short answer to all of this? What are some things you’re thinking about as you put Rocky Linux together?",
+      "a": "How do we carefully shepherd community trust? How do we ensure that anyone who wants to participate can not only do so immediately, but forever in the future as well? How do we engage and enable the community members who might not be as technical but want to contribute anyway? Solving for all of these challenges will take time, and we would love your help in doing so."
+    },
+    "q14": {
+      "q": "What if I have feedback or my question wasn’t answered here?",
+      "a": "Please email us: <a href=\"mailto:hello@rockylinux.org\">hello@rockylinux.org</a> and we’ll get back to you as soon as we can."
+    }
   }
 }

--- a/src/i18n/locales/nl/translation.json
+++ b/src/i18n/locales/nl/translation.json
@@ -1,73 +1,241 @@
 {
   "language": "nl",
-  "copyright": {
-    "line1": "© 2021 The Rocky Linux Project. Alle rechten voorbehouden.",
-    "line2": "CentOS is is een geregistreerd handelsmerk van Red Hat, Inc. Het Rocky Linux Project is niet verwant aan, noch aangeschreven door Red Hat, Inc."
-  },
-  "errors": {
-    "404": {
-      "explanation": "De aangevraagde pagina kan niet worden gevonden. Probeer het alsjeblieft nog eens.",
-      "title": "Pagina niet gevonden."
+
+  "global": {
+
+    "copyright": {
+      "line1": "© 2021 The Rocky Linux Project. Alle rechten voorbehouden.",
+      "line2": "CentOS is is een geregistreerd handelsmerk van Red Hat, Inc. Het Rocky Linux Project is niet verwant aan, noch aangeschreven door Red Hat, Inc."
+    },
+
+    "links": {
+      "close-menu": "Sluit menu",
+      "wiki": "Wiki",
+      "get-in-touch": "Kom in Contact",
+      "get-involved": "Doe Mee",
+      "go-home": "Ga naar Begin",
+      "join-the-discussion": "Doe Mee met de Discussie",
+      "posts": "News",
+      "show-your-interest": "Show Your Interest",
+      "sponsors": "Sponsors",
+      "partners": "Partners",
+      "status": "Service Status",
+      "donate": "Donate",
+      "store": "Store",
+      "press": "Press",
+      "download": "Download",
+      "com_charter": "Community Charter",
+      "org_structure": "Organization Structure",
+      "privacy": "Privacy Policy",
+      "see-more": "See More",
+      "see-all": "See All",
+      "documentation": "Documentatie",
+      "bug-report": "Report a bug"
+    },
+    "socials": {
+      "forums": "Forums",
+      "github": "Github",
+      "reddit": "Reddit",
+      "mattermost": "Mattermost",
+      "twitter": "Twitter"
     }
   },
-  "faq": {
-    "a": {
-      "come-in": "Het doel van Rocky Linux is om een downstream build te worden net zoals CentOS voorafgaand had gedaan, door het bouwen van releases nadat ze zijn toegevoegd door de upstream vendor, en niet er voor.",
-      "downstream-partner-direction": "Het CentOS project kondigde recent een verandering in de strategie aan voor CentOS. Waar voorafgaand CentOS bestond als downstream build van de upstream vendor (waar het patches en updates ontving pas nadat de upstream vendor deze kreeg), zal het veranderen naar een upstream build (met testing patches en updates voordat ze in de upstream vendor komen). Daarnaast is ondersteuning voor CentOS Linux 8 ingekort, namelijk van 31 mei 2029 naar 31 december 2021."
+
+  "homepage": {
+    "landing": {
+      "p1": {
+        "heading": "Rocky Linux",
+        "content": "Een community-gedreven project om enterprise-level, productie-klaar Linux aan te bieden."
+      },
+      "p2": {
+        "heading": "Wat is het Rocky Linux Project?",
+        "content": "Rocky Linux is een community enterprise besturingssysteem ontworpen om 100% 'bug compatible' te zijn met Amerika's top enterprise Linux distributie, omdat de downstreampartner van richting is veranderd. Het is hevig onder ontwikkeling door de community. Rocky Linux is geleid door Gregory Kurtzer, oprichter van het CentOS project. Er is geen ETA voor een release. Mensen die bijdragen worden gevraagd om contact op te nemen via de communicatie opties op deze website."
+      }
     },
-    "q": {
-      "come-in": "Dus waarom is er Rocky Linux?",
-      "downstream-partner-direction": "Wat bedoel je met, \"z'n downstreampartner is van richting veranderd?\""
-    },
-    "title": "Veelgestelde Vragen"
+    "faq": {
+      "title": "Veelgestelde Vragen",
+      "a": {
+        "come-in": "Het doel van Rocky Linux is om een downstream build te worden net zoals CentOS voorafgaand had gedaan, door het bouwen van releases nadat ze zijn toegevoegd door de upstream vendor, en niet er voor.",
+        "downstream-partner-direction": "Het CentOS project kondigde recent een verandering in de strategie aan voor CentOS. Waar voorafgaand CentOS bestond als downstream build van de upstream vendor (waar het patches en updates ontving pas nadat de upstream vendor deze kreeg), zal het veranderen naar een upstream build (met testing patches en updates voordat ze in de upstream vendor komen). Daarnaast is ondersteuning voor CentOS Linux 8 ingekort, namelijk van 31 mei 2029 naar 31 december 2021."
+      },
+      "q": {
+        "come-in": "Dus waarom is er Rocky Linux?",
+        "downstream-partner-direction": "Wat bedoel je met, \"z'n downstreampartner is van richting veranderd?\""
+      }
+    }
   },
-  "landing": {
+
+  "download": {
     "p1": {
-      "content": "Een community-gedreven project om enterprise-level, productie-klaar Linux aan te bieden.",
-      "heading": "Rocky Linux"
+      "heading": "Downloads",
+      "content": "Download the official release of Rocky Linux from one of our trusted mirrors."
+    },
+    "warning": "The release you can download here is a <i>Release Candidate</i> and should not be used in production. Please check our <a class=\"underline font-medium\" href=\"/faq/\">FAQ</a> for more information.",
+    "table": {
+      "architecture": "Architecture",
+      "iso": "ISOS",
+      "isos": {
+        "minimal": "Minimal",
+        "dvd": "DVD",
+        "boot": "Boot",
+        "checksum": "Checksum"
+      },
+      "packages": "Packages"
     },
     "p2": {
-      "content": "Rocky Linux is een community enterprise besturingssysteem ontworpen om 100% 'bug compatible' te zijn met Amerika's top enterprise Linux distributie, omdat de downstreampartner van richting is veranderd. Het is hevig onder ontwikkeling door de community. Rocky Linux is geleid door Gregory Kurtzer, oprichter van het CentOS project. Er is geen ETA voor een release. Mensen die bijdragen worden gevraagd om contact op te nemen via de communicatie opties op deze website.",
-      "heading": "Wat is het Rocky Linux Project?"
+      "content": "As you download and use Rocky Linux, the Rocky Enterprise Software Foundation invites you to <a class=\"text-green-600 dark:text-green-500 font-medium\" href=\"https://chat.rockylinux.org/\">be a part of the community as a contributor</a>. There are many ways to contribute to the project, from documentation, QA, and testing to coding changes for SIGs, providing mirroring or hosting, and helping other users."
     }
   },
+
   "lang": {
     "footer": {
-      "choose-language": "Kies een taal...",
-      "literal": "Taal:"
+      "choose-language": "Kies een taal..."
     }
   },
-  "links": {
-    "close-menu": "Sluit menu",
-    "documentation": "Documentatie",
-    "get-in-touch": "Kom in Contact",
-    "get-involved": "Doe Mee",
-    "go-home": "Ga naar Begin",
-    "join-the-discussion": "Doe Mee met de Discussie",
-    "posts": "News",
-    "show-your-interest": "Show Your Interest",
-    "sponsors": "Sponsors",
-    "donate": "Donate",
-    "store": "Store",
-    "press": "Press"
+
+  "errors": {
+    "404": {
+      "title": "Pagina niet gevonden.",
+      "explanation": "De aangevraagde pagina kan niet worden gevonden. Probeer het alsjeblieft nog eens."
+    }
   },
-  "socials": {
-    "forums": "Forums",
-    "github": "Github",
-    "reddit": "Reddit",
-    "mattermost": "Mattermost",
-    "twitter": "Twitter"
-  },
+
   "news": {
     "title": "News",
     "description": "Stay up-to-date on the latest from The Rocky Linux Project."
   },
+
   "press": {
     "title": "Press",
     "description": "See the latest about Rocky in the press."
   },
+
   "sponsors": {
     "title": "Sponsors",
-    "description": "We would like to thank our sponsors for their support thus far on the project."
+    "description": "We would like to thank our sponsors for their support thus far on the project.",
+    "tag": {
+      "fsponsor": "Founding Sponsor",
+      "psponsor": "Principal Sponsor"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "45drives": {
+        "name": "45Drives",
+        "description": "45Drives offers enterprise storage solutions built on powerful & robust open-source software that allows customers to benefit from the cost savings & flexibility of off-the-shelf hardware. Check them out for a fully supported data storage solution at the best cost per terabyte!"
+      },
+      "opendrives": {
+        "name": "OpenDrives",
+        "description": "OpenDrives is a global provider of enterprise-grade, hyper-scalable, network-attached-storage (NAS) solutions. We deliver the highest performing solutions for our customers - to match individual performance needs - for the most robust, complex and mission-critical projects and workflows, on-premises and into the cloud."
+      },
+      "montavista": {
+        "name": "MontaVista",
+        "description": "MontaVista Software is the leader in embedded commercial Linux, supporting MontaVista CGX, Yocto Project®, CentOS and Rocky Linux. MontaVista offers Open Source Software expertise, commercial-quality Linux distros, cost-effective maintenance and support for 10+ year life-cycles."
+      },
+      "aws": {
+        "name": "Amazon Web Services",
+        "description": "The RESF utilizes AWS to run much of the underlying infrastructure critical to the development and deployment of the services supporting Rocky Linux. From Koji builders for x86_64 and aarch64 running in EC2 to SRPM blob storage in S3, AWS is foundational to much of what we do."
+      }
+    }
+  },
+
+  "partners": {
+    "title": "Partners",
+    "description": "Partners of the RESF represent ongoing relationships of strategic importance to the Rocky Linux project. Through dedication of engineering expertise, infrastructure resources, or other means, their support is critical to our continued success and long term stability.",
+    "tag": {
+      "fpartner": "Founding Partner",
+      "ppartner": "Principal Partner"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "navercloud": {
+        "name": "NAVER Cloud",
+        "description": "NAVER Cloud Platform is a South Korean cloud service that started in 2017 under NAVER Cloud, a subsidiary of NAVER. It provides over 170 individual services in 2021 and holds various security certifications including CSA STAR GOLD, GDPR, and more. It also currently provides cloud services in 10 locations around the world."
+      },
+      "mattermost": {
+        "name": "Mattermost",
+        "description": "Mattermost is an open source messaging solution made for organizations with the highest security requirements. As big believers in the power of open source, Mattermost is thrilled to partner with RESF to help bring an enterprise-grade distribution of Linux to the tech community."
+      }
+    }
+  },
+
+  "faq": {
+    "heading": "Frequently Asked Questions",
+    "q1": {
+      "q": "Where can I download the release candidate?",
+      "a": "https://rockylinux.org/download"
+    },
+    "q2": {
+      "q": "What is a release candidate?",
+      "a": "A release candidate is a beta version of a product that has the potential to be stable.The intent of a release candidate is for the community to test and validate expected functionality of Rocky Linux and report any bugs if present."
+    },
+    "q3": {
+      "q": "Can I use the release candidate in production?",
+      "a": "Under no circumstance should you use a release candidate in a production environment. A release candidate is provided for testing and validation purposes only."
+    },
+    "q4": {
+      "q": "How can I help mirror the release candidate and future Rocky Linux releases?",
+      "a": "Please email <a href=\"mailto:mirrors@rockylinux.org\">mirrors@rockylinux.org</a> to express your interest."
+    },
+    "q5": {
+      "q": "I encountered a bug while testing the release candidate, what can I do?",
+      "a": "First, create an account using <a href=\"https://accounts.rockylinux.org/\"> Rocky Linux Account Services </a> , then head over to our <a href=\"https://bugs.rockylinux.org/\">Bugzilla server</a> to report any bugs."
+    },
+    "q6": {
+      "q": "How can I get involved with the Testing team?",
+      "a": "Please join the <a href=\"https://chat.rockylinux.org/rocky-linux/channels/testing\"> ~Testing </a> channel on our Mattermost server to get started. There’s also a testing topic on the forums for more durable conversation."
+    },
+    "q7": {
+      "q": "Where can I find the latest news about Rocky Linux?",
+      "a": "Stay tuned to our website, Twitter, LinkedIn, forums, and other platforms listed in our link directory for the latest announcements."
+    },
+    "q8": {
+      "q": "If Rocky Linux is just a respin of RHEL, what took so long for a release candidate?",
+      "a1": "If our only goal for Rocky Linux was to debrand and repackage RHEL, we would have been done much sooner. However, what we had to do differently is figure out how we could keep Rocky Linux in the hands of the community. Carefully devising this strategy ensures that Rocky Linux will never meet the same fate of CentOS.",
+      "a2": "The goal was not just to create a community managed RPM based distribution of Linux, but to ensure that it will remain freely available and always in the control of the community, much like Linux itself has. To do that required more than a build infrastructure; it required that we put in place the foundational structures that enable the community, ensuring that Rocky Linux is forever inclusive, free, and open. The infrastructure is built from the ground up by many collaborators and sponsoring organizations around composability and security compliance, providing the substrate for not only the base operating system but also an entire community of diverse interests to take part in the project."
+    },
+    "q9": {
+      "q": "If you’re not just repackaging RHEL, then what exactly are you doing?",
+      "a": "Our goal is to maintain Rocky Linux as a community-oriented distribution <i>by</i> the community, <i>for</i> the community. To do this, we are establishing the necessary organizational structures to ensure that Rocky Linux remains in the hands of the community. We want to make sure that it’s not possible for what happened to CentOS to happen to Rocky Linux."
+    },
+    "q10": {
+      "q": "How will you ensure that Rocky Linux truly remains a community enterprise operating system?",
+      "a": "First, we’ve taken steps to legally protect the Rocky Linux name. This means registering its trademarks and various associated properties to protect them from being controlled by another entity. We’ve achieved this by establishing them under the Rocky Enterprise Software Foundation (RESF). Next, we’re drafting a community charter that will define the organizational structure, objectives, values, and mission behind the legal entity that represents Rocky Linux. Critical in this charter is the establishment of principles that enable and protect the community: transparency, community involvement, open development, and independence. <strong> Rocky Linux will never be controlled, purchased, or otherwise influenced by a single entity or organization. </strong> Finally, we’re architecting and deploying the necessary infrastructure to further enable the community to contribute to Rocky Linux."
+    },
+    "q11": {
+      "q": "What infrastructure is necessary to enable the community?",
+      "a1": "We’ve established a number of teams to support the various efforts associated with developing Rocky Linux:",
+      "a2": "You can read more about this structure when it’s soon published. In order to enable collaboration across and within those teams, we needed to deploy our own chat infrastructure, forums, and website. Additionally, we’re also creating our build infrastructure, which will facilitate the development of the core operating system.",
+      "list": {
+        "community": "Community",
+        "core-inf": "Core Infrastructure",
+        "design": "Design",
+        "documentation": "Documentation",
+        "installer": "Installer",
+        "leadership": "Leadership",
+        "pkg-autob": "Package Auto-Builders",
+        "packaging": "Packaging",
+        "security": "Security",
+        "sigs": "Special Interest Groups (SIGs)",
+        "web": "Web"
+      }
+    },
+    "q12": {
+      "q": "Why does it take so much time to stand up a community and build infrastructure?",
+      "a": "It’s not terribly difficult to deploy a website, forums, or a build infrastructure in a reliable fashion. Our chat program for instance, which uses Mattermost, is distributed on a number of application servers behind a load balancer and was ready in just a couple of weeks. But it does require careful thought and planning to do it in a scalable and secure manner when you need to ensure vendor and platform agnosticity and long-term community involvement."
+    },
+    "q13": {
+      "q": "So what’s the short answer to all of this? What are some things you’re thinking about as you put Rocky Linux together?",
+      "a": "How do we carefully shepherd community trust? How do we ensure that anyone who wants to participate can not only do so immediately, but forever in the future as well? How do we engage and enable the community members who might not be as technical but want to contribute anyway? Solving for all of these challenges will take time, and we would love your help in doing so."
+    },
+    "q14": {
+      "q": "What if I have feedback or my question wasn’t answered here?",
+      "a": "Please email us: <a href=\"mailto:hello@rockylinux.org\">hello@rockylinux.org</a> and we’ll get back to you as soon as we can."
+    }
   }
 }

--- a/src/i18n/locales/pl/translation.json
+++ b/src/i18n/locales/pl/translation.json
@@ -1,72 +1,239 @@
 {
   "language": "pl",
-  "copyright": {
-    "line1": "© 2021 Projekt Rocky Linux. Wszelkie prawa zastrzeżone.",
-    "line2": "CentOS jest zastrzeżonym znakiem towarowym Red Hat, Inc. Projekt Rocky Linux nie jest powiązany, ani wsparty przez Red Hat, Inc."
-  },
-  "errors": {
-    "404": {
-      "explanation": "Żądany zasób nie mógł zostać zlokalizowany. Proszę spróbować jeszcze raz.",
-      "title": "Nie znaleziono strony."
+
+  "global": {
+
+    "copyright": {
+      "line1": "© 2021 Projekt Rocky Linux. Wszelkie prawa zastrzeżone.",
+      "line2": "CentOS jest zastrzeżonym znakiem towarowym Red Hat, Inc. Projekt Rocky Linux nie jest powiązany, ani wsparty przez Red Hat, Inc."
+    },
+
+    "links": {
+      "close-menu": "Zamknij menu",
+      "wiki": "Wiki",
+      "get-in-touch": "Skontaktuj się z nami",
+      "get-involved": "Zaangażuj się",
+      "go-home": "Powrót na główną",
+      "join-the-discussion": "Przyłącz się do dyskusji",
+      "posts": "Nowości",
+      "show-your-interest": "Okaż swoje zainteresowanie",
+      "sponsors": "Sponsorzy",
+      "donate": "Darowizna",
+      "store": "Sklep",
+      "press": "Prasa",
+      "download": "Download",
+      "com_charter": "Community Charter",
+      "org_structure": "Organization Structure",
+      "privacy": "Privacy Policy",
+      "see-more": "See More",
+      "see-all": "See All",
+      "documentation": "Dokumentacja",
+      "bug-report": "Report a bug"
+    },
+    "socials": {
+      "forums": "Forums",
+      "github": "Github",
+      "reddit": "Reddit",
+      "mattermost": "Mattermost",
+      "twitter": "Twitter"
     }
   },
-  "faq": {
-    "a": {
-      "come-in": "Rocky Linux ma na celu funkcjonowanie jako kompilacja downstream, tak jak CentOS robił to wcześniej, budując wydania po dodaniu ich do dostawcy upstream, a nie wcześniej.",
-      "downstream-partner-direction": "Projekt CentOS niedawno ogłosił zmianę kierunku rozwoju. Mając na uwadze, że wcześniej CentOS istniał jako kompilacja tzw. downstream swojego dostawcy wyższego szczebla (otrzymuje łatki i aktualizacje po tym, jak dostawca wyższego szczebla je otrzymuje), zostanie on przeniesiony do kompilacji upstream (testowanie łatek i aktualizacji przed włączeniem do dostawcy wyższego szczebla)."
+
+  "homepage": {
+    "landing": {
+      "p1": {
+        "heading": "Rocky Linux",
+        "content": "Inicjatywa społecznościowa w celu stworzenia biznesowej klasy, gotowego do wykorzystania produkcyjnego Linuksa."
+      },
+      "p2": {
+        "heading": "Czym jest projekt Rocky Linux?",
+        "content": "Rocky Linux jest społecznościowym systemem operacyjnym klasy biznesowej, zaprojektowanym aby być w 100% błąd-za-błędem kompatybilnym z najlepszą korporacyjną dystrybucją amerykańskiego systemu Linux, kiedy to jej mniejszy partner zmienił kierunek rozwoju. Jest on intensywnie rozwijany przez społeczność. Rocky Linux jest prowadzony przez Gregory'ego Kurtzera, założyciela projektu CentOS. Nie ma żadnego szacunkowego czasu wydania. Chętni do współpracy proszeni są o kontakt za pomocą źródeł komunikacji oferowanych na tej stronie."
+      }
     },
-    "q": {
-      "come-in": "Więc gdzie jest miejsce dla Rocky Linux?",
-      "downstream-partner-direction": "Co masz na myśli mówiąc, \"jej partner zmienił kierunek rozwoju?\""
-    },
-    "title": "Najczęściej zadawane pytania (FAQ)"
+    "faq": {
+      "title": "Najczęściej zadawane pytania (FAQ)",
+      "a": {
+        "come-in": "Rocky Linux ma na celu funkcjonowanie jako kompilacja downstream, tak jak CentOS robił to wcześniej, budując wydania po dodaniu ich do dostawcy upstream, a nie wcześniej.",
+        "downstream-partner-direction": "Projekt CentOS niedawno ogłosił zmianę kierunku rozwoju. Mając na uwadze, że wcześniej CentOS istniał jako kompilacja tzw. downstream swojego dostawcy wyższego szczebla (otrzymuje łatki i aktualizacje po tym, jak dostawca wyższego szczebla je otrzymuje), zostanie on przeniesiony do kompilacji upstream (testowanie łatek i aktualizacji przed włączeniem do dostawcy wyższego szczebla)."
+      },
+      "q": {
+        "come-in": "Więc gdzie jest miejsce dla Rocky Linux?",
+        "downstream-partner-direction": "Co masz na myśli mówiąc, \"jej partner zmienił kierunek rozwoju?\""
+      }
+    }
   },
-  "landing": {
+
+  "download": {
     "p1": {
-      "content": "Inicjatywa społecznościowa w celu stworzenia biznesowej klasy, gotowego do wykorzystania produkcyjnego Linuksa.",
-      "heading": "Rocky Linux"
+      "heading": "Downloads",
+      "content": "Download the official release of Rocky Linux from one of our trusted mirrors."
+    },
+    "warning": "The release you can download here is a <i>Release Candidate</i> and should not be used in production. Please check our <a class=\"underline font-medium\" href=\"/faq/\">FAQ</a> for more information.",
+    "table": {
+      "architecture": "Architecture",
+      "iso": "ISOS",
+      "isos": {
+        "minimal": "Minimal",
+        "dvd": "DVD",
+        "boot": "Boot",
+        "checksum": "Checksum"
+      },
+      "packages": "Packages"
     },
     "p2": {
-      "content": "Rocky Linux jest społecznościowym systemem operacyjnym klasy biznesowej, zaprojektowanym aby być w 100% błąd-za-błędem kompatybilnym z najlepszą korporacyjną dystrybucją amerykańskiego systemu Linux, kiedy to jej mniejszy partner zmienił kierunek rozwoju. Jest on intensywnie rozwijany przez społeczność. Rocky Linux jest prowadzony przez Gregory'ego Kurtzera, założyciela projektu CentOS. Nie ma żadnego szacunkowego czasu wydania. Chętni do współpracy proszeni są o kontakt za pomocą źródeł komunikacji oferowanych na tej stronie.",
-      "heading": "Czym jest projekt Rocky Linux?"
+      "content": "As you download and use Rocky Linux, the Rocky Enterprise Software Foundation invites you to <a class=\"text-green-600 dark:text-green-500 font-medium\" href=\"https://chat.rockylinux.org/\">be a part of the community as a contributor</a>. There are many ways to contribute to the project, from documentation, QA, and testing to coding changes for SIGs, providing mirroring or hosting, and helping other users."
     }
   },
+
   "lang": {
     "footer": {
       "choose-language": "Wybierz język..."
     }
   },
-  "links": {
-    "close-menu": "Zamknij menu",
-    "documentation": "Dokumentacja",
-    "get-in-touch": "Skontaktuj się z nami",
-    "get-involved": "Zaangażuj się",
-    "go-home": "Powrót na główną",
-    "join-the-discussion": "Przyłącz się do dyskusji",
-    "posts": "Nowości",
-    "show-your-interest": "Okaż swoje zainteresowanie",
-    "sponsors": "Sponsorzy",
-    "donate": "Darowizna",
-    "store": "Sklep",
-    "press": "Prasa"
+
+  "errors": {
+    "404": {
+      "title": "Nie znaleziono strony.",
+      "explanation": "Żądany zasób nie mógł zostać zlokalizowany. Proszę spróbować jeszcze raz."
+    }
   },
-  "socials": {
-    "forums": "Forum",
-    "github": "Github",
-    "reddit": "Reddit",
-    "mattermost": "Mattermost",
-    "twitter": "Twitter"
-  },
+
   "news": {
     "title": "Nowości",
     "description": "Bądź na bieżąco z najnowszymi informacjami z The Rocky Linux Project."
   },
+
   "press": {
     "title": "Prasa",
     "description": "Zobacz najnowsze doniesienia prasowe na temat Rocky."
   },
+
   "sponsors": {
     "title": "Sponsorzy",
-    "description": "Chcielibyśmy podziękować naszym sponsorom za ich dotychczasowe wsparcie przy realizacji projektu."
+    "description": "Chcielibyśmy podziękować naszym sponsorom za ich dotychczasowe wsparcie przy realizacji projektu.",
+    "tag": {
+      "fsponsor": "Founding Sponsor",
+      "psponsor": "Principal Sponsor"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "45drives": {
+        "name": "45Drives",
+        "description": "45Drives offers enterprise storage solutions built on powerful & robust open-source software that allows customers to benefit from the cost savings & flexibility of off-the-shelf hardware. Check them out for a fully supported data storage solution at the best cost per terabyte!"
+      },
+      "opendrives": {
+        "name": "OpenDrives",
+        "description": "OpenDrives is a global provider of enterprise-grade, hyper-scalable, network-attached-storage (NAS) solutions. We deliver the highest performing solutions for our customers - to match individual performance needs - for the most robust, complex and mission-critical projects and workflows, on-premises and into the cloud."
+      },
+      "montavista": {
+        "name": "MontaVista",
+        "description": "MontaVista Software is the leader in embedded commercial Linux, supporting MontaVista CGX, Yocto Project®, CentOS and Rocky Linux. MontaVista offers Open Source Software expertise, commercial-quality Linux distros, cost-effective maintenance and support for 10+ year life-cycles."
+      },
+      "aws": {
+        "name": "Amazon Web Services",
+        "description": "The RESF utilizes AWS to run much of the underlying infrastructure critical to the development and deployment of the services supporting Rocky Linux. From Koji builders for x86_64 and aarch64 running in EC2 to SRPM blob storage in S3, AWS is foundational to much of what we do."
+      }
+    }
+  },
+
+  "partners": {
+    "title": "Partners",
+    "description": "Partners of the RESF represent ongoing relationships of strategic importance to the Rocky Linux project. Through dedication of engineering expertise, infrastructure resources, or other means, their support is critical to our continued success and long term stability.",
+    "tag": {
+      "fpartner": "Founding Partner",
+      "ppartner": "Principal Partner"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "navercloud": {
+        "name": "NAVER Cloud",
+        "description": "NAVER Cloud Platform is a South Korean cloud service that started in 2017 under NAVER Cloud, a subsidiary of NAVER. It provides over 170 individual services in 2021 and holds various security certifications including CSA STAR GOLD, GDPR, and more. It also currently provides cloud services in 10 locations around the world."
+      },
+      "mattermost": {
+        "name": "Mattermost",
+        "description": "Mattermost is an open source messaging solution made for organizations with the highest security requirements. As big believers in the power of open source, Mattermost is thrilled to partner with RESF to help bring an enterprise-grade distribution of Linux to the tech community."
+      }
+    }
+  },
+
+  "faq": {
+    "heading": "Frequently Asked Questions",
+    "q1": {
+      "q": "Where can I download the release candidate?",
+      "a": "https://rockylinux.org/download"
+    },
+    "q2": {
+      "q": "What is a release candidate?",
+      "a": "A release candidate is a beta version of a product that has the potential to be stable.The intent of a release candidate is for the community to test and validate expected functionality of Rocky Linux and report any bugs if present."
+    },
+    "q3": {
+      "q": "Can I use the release candidate in production?",
+      "a": "Under no circumstance should you use a release candidate in a production environment. A release candidate is provided for testing and validation purposes only."
+    },
+    "q4": {
+      "q": "How can I help mirror the release candidate and future Rocky Linux releases?",
+      "a": "Please email <a href=\"mailto:mirrors@rockylinux.org\">mirrors@rockylinux.org</a> to express your interest."
+    },
+    "q5": {
+      "q": "I encountered a bug while testing the release candidate, what can I do?",
+      "a": "First, create an account using <a href=\"https://accounts.rockylinux.org/\"> Rocky Linux Account Services </a> , then head over to our <a href=\"https://bugs.rockylinux.org/\">Bugzilla server</a> to report any bugs."
+    },
+    "q6": {
+      "q": "How can I get involved with the Testing team?",
+      "a": "Please join the <a href=\"https://chat.rockylinux.org/rocky-linux/channels/testing\"> ~Testing </a> channel on our Mattermost server to get started. There’s also a testing topic on the forums for more durable conversation."
+    },
+    "q7": {
+      "q": "Where can I find the latest news about Rocky Linux?",
+      "a": "Stay tuned to our website, Twitter, LinkedIn, forums, and other platforms listed in our link directory for the latest announcements."
+    },
+    "q8": {
+      "q": "If Rocky Linux is just a respin of RHEL, what took so long for a release candidate?",
+      "a1": "If our only goal for Rocky Linux was to debrand and repackage RHEL, we would have been done much sooner. However, what we had to do differently is figure out how we could keep Rocky Linux in the hands of the community. Carefully devising this strategy ensures that Rocky Linux will never meet the same fate of CentOS.",
+      "a2": "The goal was not just to create a community managed RPM based distribution of Linux, but to ensure that it will remain freely available and always in the control of the community, much like Linux itself has. To do that required more than a build infrastructure; it required that we put in place the foundational structures that enable the community, ensuring that Rocky Linux is forever inclusive, free, and open. The infrastructure is built from the ground up by many collaborators and sponsoring organizations around composability and security compliance, providing the substrate for not only the base operating system but also an entire community of diverse interests to take part in the project."
+    },
+    "q9": {
+      "q": "If you’re not just repackaging RHEL, then what exactly are you doing?",
+      "a": "Our goal is to maintain Rocky Linux as a community-oriented distribution <i>by</i> the community, <i>for</i> the community. To do this, we are establishing the necessary organizational structures to ensure that Rocky Linux remains in the hands of the community. We want to make sure that it’s not possible for what happened to CentOS to happen to Rocky Linux."
+    },
+    "q10": {
+      "q": "How will you ensure that Rocky Linux truly remains a community enterprise operating system?",
+      "a": "First, we’ve taken steps to legally protect the Rocky Linux name. This means registering its trademarks and various associated properties to protect them from being controlled by another entity. We’ve achieved this by establishing them under the Rocky Enterprise Software Foundation (RESF). Next, we’re drafting a community charter that will define the organizational structure, objectives, values, and mission behind the legal entity that represents Rocky Linux. Critical in this charter is the establishment of principles that enable and protect the community: transparency, community involvement, open development, and independence. <strong> Rocky Linux will never be controlled, purchased, or otherwise influenced by a single entity or organization. </strong> Finally, we’re architecting and deploying the necessary infrastructure to further enable the community to contribute to Rocky Linux."
+    },
+    "q11": {
+      "q": "What infrastructure is necessary to enable the community?",
+      "a1": "We’ve established a number of teams to support the various efforts associated with developing Rocky Linux:",
+      "a2": "You can read more about this structure when it’s soon published. In order to enable collaboration across and within those teams, we needed to deploy our own chat infrastructure, forums, and website. Additionally, we’re also creating our build infrastructure, which will facilitate the development of the core operating system.",
+      "list": {
+        "community": "Community",
+        "core-inf": "Core Infrastructure",
+        "design": "Design",
+        "documentation": "Documentation",
+        "installer": "Installer",
+        "leadership": "Leadership",
+        "pkg-autob": "Package Auto-Builders",
+        "packaging": "Packaging",
+        "security": "Security",
+        "sigs": "Special Interest Groups (SIGs)",
+        "web": "Web"
+      }
+    },
+    "q12": {
+      "q": "Why does it take so much time to stand up a community and build infrastructure?",
+      "a": "It’s not terribly difficult to deploy a website, forums, or a build infrastructure in a reliable fashion. Our chat program for instance, which uses Mattermost, is distributed on a number of application servers behind a load balancer and was ready in just a couple of weeks. But it does require careful thought and planning to do it in a scalable and secure manner when you need to ensure vendor and platform agnosticity and long-term community involvement."
+    },
+    "q13": {
+      "q": "So what’s the short answer to all of this? What are some things you’re thinking about as you put Rocky Linux together?",
+      "a": "How do we carefully shepherd community trust? How do we ensure that anyone who wants to participate can not only do so immediately, but forever in the future as well? How do we engage and enable the community members who might not be as technical but want to contribute anyway? Solving for all of these challenges will take time, and we would love your help in doing so."
+    },
+    "q14": {
+      "q": "What if I have feedback or my question wasn’t answered here?",
+      "a": "Please email us: <a href=\"mailto:hello@rockylinux.org\">hello@rockylinux.org</a> and we’ll get back to you as soon as we can."
+    }
   }
 }

--- a/src/i18n/locales/pt-br/translation.json
+++ b/src/i18n/locales/pt-br/translation.json
@@ -1,73 +1,241 @@
 {
   "language": "pt-br",
-  "copyright": {
-    "line1": "© 2021 O projeto Rocky Linux. Todos os direitos reservados.",
-    "line2": "CentOS é uma marca registrada de Red Hat, Inc. O projeto Rocky Linux não está afiliado nem respaldado pela Red Hat, Inc."
-  },
-  "errors": {
-    "404": {
-      "explanation": "Não se pode encontrar o recurso solicitado. Tente novamente.",
-      "title": "Página não encontrada."
+
+  "global": {
+
+    "copyright": {
+      "line1": "© 2021 O projeto Rocky Linux. Todos os direitos reservados.",
+      "line2": "CentOS é uma marca registrada de Red Hat, Inc. O projeto Rocky Linux não está afiliado nem respaldado pela Red Hat, Inc."
+    },
+
+    "links": {
+      "close-menu": "Fechar menu",
+      "wiki": "Wiki",
+      "get-in-touch": "Entrar em contato",
+      "get-involved": "Envolva-se",
+      "go-home": "Início",
+      "join-the-discussion": "Juntar-se à discussão",
+      "posts": "News",
+      "show-your-interest": "Show Your Interest",
+      "sponsors": "Sponsors",
+      "partners": "Partners",
+      "status": "Service Status",
+      "donate": "Donate",
+      "store": "Store",
+      "press": "Press",
+      "download": "Download",
+      "com_charter": "Community Charter",
+      "org_structure": "Organization Structure",
+      "privacy": "Privacy Policy",
+      "see-more": "See More",
+      "see-all": "See All",
+      "documentation": "Documentação",
+      "bug-report": "Report a bug"
+    },
+    "socials": {
+      "forums": "Fóruns",
+      "github": "Github",
+      "reddit": "Reddit",
+      "mattermost": "Mattermost",
+      "twitter": "Twitter"
     }
   },
-  "faq": {
-    "a": {
-      "come-in": "O Rocky Linux tem como objetivo funcionar como um build não principal como o CentOS fazia anteriormente, criando releases depois de serem adicionados pelo fornecedor principal e não antes.",
-      "downstream-partner-direction": "O projeto CentOS anunciou recentemente uma mudança na estratégia do CentOS. Considerando que o CentOS existia anteriormente como um build não principal de seu fornecedor principal (ou seja, ele recebe patches e atualizações após o fornecedor principal), ele mudará para um build principal (testes de patches e atualizações antes da inclusão no fornecedor principal). Além disso, o suporte para CentOS Linux 8 foi interrompido, de 31 de maio de 2029 para 31 de dezembro de 2021."
+
+  "homepage": {
+    "landing": {
+      "p1": {
+        "heading": "Rocky Linux",
+        "content": "Um esforço conduzido pela comunidade para obter um sistema Linux de classe empresarial pronto para produção."
+      },
+      "p2": {
+        "heading": "O que é o projeto Rocky Linux?",
+        "content": "O Rocky Linux é um sistema operacional empresarial comunitário desenhado para ser 100% compatível com a distribuição Linux empresarial mais importante dos Estados Unidos agora que o seu parceiro de negócio mudou de direção. Está em desenvolvimento intenso por parte da comunidade. O Rocky Linux é liderado por Gregory Kurtzer, fundador do projeto CentOS. Não há uma data para liberação. Solicitamos aos colaboradores que se comuniquem com as opções de comunicação que oferecemos no site."
+      }
     },
-    "q": {
-      "come-in": "Então, onde entra o Rocky Linux?",
-      "downstream-partner-direction": "O que você quer dizer com, \"seu parceiro de negócio mudou de direção?\""
-    },
-    "title": "Perguntas frequentes"
+    "faq": {
+      "title": "Perguntas frequentes",
+      "a": {
+        "come-in": "O Rocky Linux tem como objetivo funcionar como um build não principal como o CentOS fazia anteriormente, criando releases depois de serem adicionados pelo fornecedor principal e não antes.",
+        "downstream-partner-direction": "O projeto CentOS anunciou recentemente uma mudança na estratégia do CentOS. Considerando que o CentOS existia anteriormente como um build não principal de seu fornecedor principal (ou seja, ele recebe patches e atualizações após o fornecedor principal), ele mudará para um build principal (testes de patches e atualizações antes da inclusão no fornecedor principal). Além disso, o suporte para CentOS Linux 8 foi interrompido, de 31 de maio de 2029 para 31 de dezembro de 2021."
+      },
+      "q": {
+        "come-in": "Então, onde entra o Rocky Linux?",
+        "downstream-partner-direction": "O que você quer dizer com, \"seu parceiro de negócio mudou de direção?\""
+      }
+    }
   },
-  "landing": {
+
+  "download": {
     "p1": {
-      "content": "Um esforço conduzido pela comunidade para obter um sistema Linux de classe empresarial pronto para produção.",
-      "heading": "Rocky Linux"
+      "heading": "Downloads",
+      "content": "Download the official release of Rocky Linux from one of our trusted mirrors."
+    },
+    "warning": "The release you can download here is a <i>Release Candidate</i> and should not be used in production. Please check our <a class=\"underline font-medium\" href=\"/faq/\">FAQ</a> for more information.",
+    "table": {
+      "architecture": "Architecture",
+      "iso": "ISOS",
+      "isos": {
+        "minimal": "Minimal",
+        "dvd": "DVD",
+        "boot": "Boot",
+        "checksum": "Checksum"
+      },
+      "packages": "Packages"
     },
     "p2": {
-      "content": "O Rocky Linux é um sistema operacional empresarial comunitário desenhado para ser 100% compatível com a distribuição Linux empresarial mais importante dos Estados Unidos agora que o seu parceiro de negócio mudou de direção. Está em desenvolvimento intenso por parte da comunidade. O Rocky Linux é liderado por Gregory Kurtzer, fundador do projeto CentOS. Não há uma data para liberação. Solicitamos aos colaboradores que se comuniquem com as opções de comunicação que oferecemos no site.",
-      "heading": "O que é o projeto Rocky Linux?"
+      "content": "As you download and use Rocky Linux, the Rocky Enterprise Software Foundation invites you to <a class=\"text-green-600 dark:text-green-500 font-medium\" href=\"https://chat.rockylinux.org/\">be a part of the community as a contributor</a>. There are many ways to contribute to the project, from documentation, QA, and testing to coding changes for SIGs, providing mirroring or hosting, and helping other users."
     }
   },
+
   "lang": {
     "footer": {
-      "choose-language": "Escolha o idioma...",
-      "literal": "Idioma:"
+      "choose-language": "Escolha o idioma..."
     }
   },
-  "links": {
-    "close-menu": "Fechar menu",
-    "documentation": "Documentação",
-    "get-in-touch": "Entrar em contato",
-    "get-involved": "Envolva-se",
-    "go-home": "Início",
-    "join-the-discussion": "Juntar-se à discussão",
-    "posts": "News",
-    "show-your-interest": "Show Your Interest",
-    "sponsors": "Sponsors",
-    "donate": "Donate",
-    "store": "Store",
-    "press": "Press"
+
+  "errors": {
+    "404": {
+      "title": "Página não encontrada.",
+      "explanation": "Não se pode encontrar o recurso solicitado. Tente novamente."
+    }
   },
-  "socials": {
-    "forums": "Fóruns",
-    "github": "Github",
-    "reddit": "Reddit",
-    "mattermost": "Mattermost",
-    "twitter": "Twitter"
-  },
+
   "news": {
     "title": "News",
     "description": "Stay up-to-date on the latest from The Rocky Linux Project."
   },
+
   "press": {
     "title": "Press",
     "description": "See the latest about Rocky in the press."
   },
+
   "sponsors": {
     "title": "Sponsors",
-    "description": "We would like to thank our sponsors for their support thus far on the project."
+    "description": "We would like to thank our sponsors for their support thus far on the project.",
+    "tag": {
+      "fsponsor": "Founding Sponsor",
+      "psponsor": "Principal Sponsor"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "45drives": {
+        "name": "45Drives",
+        "description": "45Drives offers enterprise storage solutions built on powerful & robust open-source software that allows customers to benefit from the cost savings & flexibility of off-the-shelf hardware. Check them out for a fully supported data storage solution at the best cost per terabyte!"
+      },
+      "opendrives": {
+        "name": "OpenDrives",
+        "description": "OpenDrives is a global provider of enterprise-grade, hyper-scalable, network-attached-storage (NAS) solutions. We deliver the highest performing solutions for our customers - to match individual performance needs - for the most robust, complex and mission-critical projects and workflows, on-premises and into the cloud."
+      },
+      "montavista": {
+        "name": "MontaVista",
+        "description": "MontaVista Software is the leader in embedded commercial Linux, supporting MontaVista CGX, Yocto Project®, CentOS and Rocky Linux. MontaVista offers Open Source Software expertise, commercial-quality Linux distros, cost-effective maintenance and support for 10+ year life-cycles."
+      },
+      "aws": {
+        "name": "Amazon Web Services",
+        "description": "The RESF utilizes AWS to run much of the underlying infrastructure critical to the development and deployment of the services supporting Rocky Linux. From Koji builders for x86_64 and aarch64 running in EC2 to SRPM blob storage in S3, AWS is foundational to much of what we do."
+      }
+    }
+  },
+
+  "partners": {
+    "title": "Partners",
+    "description": "Partners of the RESF represent ongoing relationships of strategic importance to the Rocky Linux project. Through dedication of engineering expertise, infrastructure resources, or other means, their support is critical to our continued success and long term stability.",
+    "tag": {
+      "fpartner": "Founding Partner",
+      "ppartner": "Principal Partner"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "navercloud": {
+        "name": "NAVER Cloud",
+        "description": "NAVER Cloud Platform is a South Korean cloud service that started in 2017 under NAVER Cloud, a subsidiary of NAVER. It provides over 170 individual services in 2021 and holds various security certifications including CSA STAR GOLD, GDPR, and more. It also currently provides cloud services in 10 locations around the world."
+      },
+      "mattermost": {
+        "name": "Mattermost",
+        "description": "Mattermost is an open source messaging solution made for organizations with the highest security requirements. As big believers in the power of open source, Mattermost is thrilled to partner with RESF to help bring an enterprise-grade distribution of Linux to the tech community."
+      }
+    }
+  },
+
+  "faq": {
+    "heading": "Frequently Asked Questions",
+    "q1": {
+      "q": "Where can I download the release candidate?",
+      "a": "https://rockylinux.org/download"
+    },
+    "q2": {
+      "q": "What is a release candidate?",
+      "a": "A release candidate is a beta version of a product that has the potential to be stable.The intent of a release candidate is for the community to test and validate expected functionality of Rocky Linux and report any bugs if present."
+    },
+    "q3": {
+      "q": "Can I use the release candidate in production?",
+      "a": "Under no circumstance should you use a release candidate in a production environment. A release candidate is provided for testing and validation purposes only."
+    },
+    "q4": {
+      "q": "How can I help mirror the release candidate and future Rocky Linux releases?",
+      "a": "Please email <a href=\"mailto:mirrors@rockylinux.org\">mirrors@rockylinux.org</a> to express your interest."
+    },
+    "q5": {
+      "q": "I encountered a bug while testing the release candidate, what can I do?",
+      "a": "First, create an account using <a href=\"https://accounts.rockylinux.org/\"> Rocky Linux Account Services </a> , then head over to our <a href=\"https://bugs.rockylinux.org/\">Bugzilla server</a> to report any bugs."
+    },
+    "q6": {
+      "q": "How can I get involved with the Testing team?",
+      "a": "Please join the <a href=\"https://chat.rockylinux.org/rocky-linux/channels/testing\"> ~Testing </a> channel on our Mattermost server to get started. There’s also a testing topic on the forums for more durable conversation."
+    },
+    "q7": {
+      "q": "Where can I find the latest news about Rocky Linux?",
+      "a": "Stay tuned to our website, Twitter, LinkedIn, forums, and other platforms listed in our link directory for the latest announcements."
+    },
+    "q8": {
+      "q": "If Rocky Linux is just a respin of RHEL, what took so long for a release candidate?",
+      "a1": "If our only goal for Rocky Linux was to debrand and repackage RHEL, we would have been done much sooner. However, what we had to do differently is figure out how we could keep Rocky Linux in the hands of the community. Carefully devising this strategy ensures that Rocky Linux will never meet the same fate of CentOS.",
+      "a2": "The goal was not just to create a community managed RPM based distribution of Linux, but to ensure that it will remain freely available and always in the control of the community, much like Linux itself has. To do that required more than a build infrastructure; it required that we put in place the foundational structures that enable the community, ensuring that Rocky Linux is forever inclusive, free, and open. The infrastructure is built from the ground up by many collaborators and sponsoring organizations around composability and security compliance, providing the substrate for not only the base operating system but also an entire community of diverse interests to take part in the project."
+    },
+    "q9": {
+      "q": "If you’re not just repackaging RHEL, then what exactly are you doing?",
+      "a": "Our goal is to maintain Rocky Linux as a community-oriented distribution <i>by</i> the community, <i>for</i> the community. To do this, we are establishing the necessary organizational structures to ensure that Rocky Linux remains in the hands of the community. We want to make sure that it’s not possible for what happened to CentOS to happen to Rocky Linux."
+    },
+    "q10": {
+      "q": "How will you ensure that Rocky Linux truly remains a community enterprise operating system?",
+      "a": "First, we’ve taken steps to legally protect the Rocky Linux name. This means registering its trademarks and various associated properties to protect them from being controlled by another entity. We’ve achieved this by establishing them under the Rocky Enterprise Software Foundation (RESF). Next, we’re drafting a community charter that will define the organizational structure, objectives, values, and mission behind the legal entity that represents Rocky Linux. Critical in this charter is the establishment of principles that enable and protect the community: transparency, community involvement, open development, and independence. <strong> Rocky Linux will never be controlled, purchased, or otherwise influenced by a single entity or organization. </strong> Finally, we’re architecting and deploying the necessary infrastructure to further enable the community to contribute to Rocky Linux."
+    },
+    "q11": {
+      "q": "What infrastructure is necessary to enable the community?",
+      "a1": "We’ve established a number of teams to support the various efforts associated with developing Rocky Linux:",
+      "a2": "You can read more about this structure when it’s soon published. In order to enable collaboration across and within those teams, we needed to deploy our own chat infrastructure, forums, and website. Additionally, we’re also creating our build infrastructure, which will facilitate the development of the core operating system.",
+      "list": {
+        "community": "Community",
+        "core-inf": "Core Infrastructure",
+        "design": "Design",
+        "documentation": "Documentation",
+        "installer": "Installer",
+        "leadership": "Leadership",
+        "pkg-autob": "Package Auto-Builders",
+        "packaging": "Packaging",
+        "security": "Security",
+        "sigs": "Special Interest Groups (SIGs)",
+        "web": "Web"
+      }
+    },
+    "q12": {
+      "q": "Why does it take so much time to stand up a community and build infrastructure?",
+      "a": "It’s not terribly difficult to deploy a website, forums, or a build infrastructure in a reliable fashion. Our chat program for instance, which uses Mattermost, is distributed on a number of application servers behind a load balancer and was ready in just a couple of weeks. But it does require careful thought and planning to do it in a scalable and secure manner when you need to ensure vendor and platform agnosticity and long-term community involvement."
+    },
+    "q13": {
+      "q": "So what’s the short answer to all of this? What are some things you’re thinking about as you put Rocky Linux together?",
+      "a": "How do we carefully shepherd community trust? How do we ensure that anyone who wants to participate can not only do so immediately, but forever in the future as well? How do we engage and enable the community members who might not be as technical but want to contribute anyway? Solving for all of these challenges will take time, and we would love your help in doing so."
+    },
+    "q14": {
+      "q": "What if I have feedback or my question wasn’t answered here?",
+      "a": "Please email us: <a href=\"mailto:hello@rockylinux.org\">hello@rockylinux.org</a> and we’ll get back to you as soon as we can."
+    }
   }
 }

--- a/src/i18n/locales/pt-pt/translation.json
+++ b/src/i18n/locales/pt-pt/translation.json
@@ -1,72 +1,241 @@
 {
   "language": "pt-pt",
-  "copyright": {
-    "line1": "© 2021 O Projeto Rocky Linux. Todos os direitos reservados.",
-    "line2": "CentOS é uma marca registada de Red Hat, Inc. O projeto Rocky Linux não está afiliado, nem é apoiado por Red Hat, Inc."
-  },
-  "errors": {
-    "404": {
-      "explanation": "Não foi possível localizar o recurso solicitado. Por favor tente novamente.",
-      "title": "Página não encontrada."
+
+  "global": {
+
+    "copyright": {
+      "line1": "© 2021 O Projeto Rocky Linux. Todos os direitos reservados.",
+      "line2": "CentOS é uma marca registada de Red Hat, Inc. O projeto Rocky Linux não está afiliado, nem é apoiado por Red Hat, Inc."
+    },
+
+    "links": {
+      "close-menu": "Fechar menu",
+      "wiki": "Wiki",
+      "get-in-touch": "Entrar em Contacto",
+      "get-involved": "Envolver-se",
+      "go-home": "Início",
+      "join-the-discussion": "Junte-se à Discussão",
+      "posts": "News",
+      "show-your-interest": "Show Your Interest",
+      "sponsors": "Sponsors",
+      "partners": "Partners",
+      "status": "Service Status",
+      "donate": "Donate",
+      "store": "Store",
+      "press": "Press",
+      "download": "Download",
+      "com_charter": "Community Charter",
+      "org_structure": "Organization Structure",
+      "privacy": "Privacy Policy",
+      "see-more": "See More",
+      "see-all": "See All",
+      "documentation": "Documentação",
+      "bug-report": "Report a bug"
+    },
+    "socials": {
+      "forums": "Forums",
+      "github": "Github",
+      "reddit": "Reddit",
+      "mattermost": "Mattermost",
+      "twitter": "Twitter"
     }
   },
-  "faq": {
-    "a": {
-      "come-in": "O Rocky Linux pretende funcionar como uma compilação descendente, tal como o CentOS fazia anteriormente, construindo versões após estas terem sido adicionadas pelo provedor ascendente, não antes.",
-      "downstream-partner-direction": "O projeto CentOS anuciou recentemente uma mudança de estratégia para o CentOS. Enquanto que anteriormente o CentOS existia como uma compilação descendente do seu provedor ascendente (recebe correções e atualizações depois do provedor ascendente), agora passará a uma compilação ascendente (testando correções e atualizações antes da sua inclusão no provedor ascendente). Além disso, o suporte do CentOS Linux 8 foi reduzido, de 31 de maio de 2029 para 31 de dezembro de 2021."
+
+  "homepage": {
+    "landing": {
+      "p1": {
+        "heading": "Rocky Linux",
+        "content": "Um esforço conduzido pela comunidade para fornecer um sistema Linux de nível empresarial, preparado para produção."
+      },
+      "p2": {
+        "heading": "O que é o Projeto Rocky Linux?",
+        "content": "O Rocky Linux é um sistema operativo empresarial comunitário desenhado para ser 100% compatível com a distribuição de Linux empresarial mais importante dos Estados Unidos agora que o seu parceiro descendente mudou de direção. Este encontra-se sob um intenso desenvolvimento pela comunidade. O Rocky Linux é liderado por Gregory Kurtzer, fundador do projeto CentOS. Ainda não existe data para um lançamento. Solicita-se aos colaboradores que comuniquem através das opções de comunicação disponibilizadas neste site."
+      }
     },
-    "q": {
-      "come-in": "Então, onde entra o Rocky Linux?",
-      "downstream-partner-direction": "O que significa, \"o parceiro descendente mudou de direção?\""
-    },
-    "title": "Perguntas Frequentes"
+    "faq": {
+      "title": "Perguntas Frequentes",
+      "a": {
+        "come-in": "O Rocky Linux pretende funcionar como uma compilação descendente, tal como o CentOS fazia anteriormente, construindo versões após estas terem sido adicionadas pelo provedor ascendente, não antes.",
+        "downstream-partner-direction": "O projeto CentOS anuciou recentemente uma mudança de estratégia para o CentOS. Enquanto que anteriormente o CentOS existia como uma compilação descendente do seu provedor ascendente (recebe correções e atualizações depois do provedor ascendente), agora passará a uma compilação ascendente (testando correções e atualizações antes da sua inclusão no provedor ascendente). Além disso, o suporte do CentOS Linux 8 foi reduzido, de 31 de maio de 2029 para 31 de dezembro de 2021."
+      },
+      "q": {
+        "come-in": "Então, onde entra o Rocky Linux?",
+        "downstream-partner-direction": "O que significa, \"o parceiro descendente mudou de direção?\""
+      }
+    }
   },
-  "landing": {
+
+  "download": {
     "p1": {
-      "content": "Um esforço conduzido pela comunidade para fornecer um sistema Linux de nível empresarial, preparado para produção.",
-      "heading": "Rocky Linux"
+      "heading": "Downloads",
+      "content": "Download the official release of Rocky Linux from one of our trusted mirrors."
+    },
+    "warning": "The release you can download here is a <i>Release Candidate</i> and should not be used in production. Please check our <a class=\"underline font-medium\" href=\"/faq/\">FAQ</a> for more information.",
+    "table": {
+      "architecture": "Architecture",
+      "iso": "ISOS",
+      "isos": {
+        "minimal": "Minimal",
+        "dvd": "DVD",
+        "boot": "Boot",
+        "checksum": "Checksum"
+      },
+      "packages": "Packages"
     },
     "p2": {
-      "content": "O Rocky Linux é um sistema operativo empresarial comunitário desenhado para ser 100% compatível com a distribuição de Linux empresarial mais importante dos Estados Unidos agora que o seu parceiro descendente mudou de direção. Este encontra-se sob um intenso desenvolvimento pela comunidade. O Rocky Linux é liderado por Gregory Kurtzer, fundador do projeto CentOS. Ainda não existe data para um lançamento. Solicita-se aos colaboradores que comuniquem através das opções de comunicação disponibilizadas neste site.",
-      "heading": "O que é o Projeto Rocky Linux?"
+      "content": "As you download and use Rocky Linux, the Rocky Enterprise Software Foundation invites you to <a class=\"text-green-600 dark:text-green-500 font-medium\" href=\"https://chat.rockylinux.org/\">be a part of the community as a contributor</a>. There are many ways to contribute to the project, from documentation, QA, and testing to coding changes for SIGs, providing mirroring or hosting, and helping other users."
     }
   },
+
   "lang": {
     "footer": {
       "choose-language": "Selecionar idioma..."
     }
   },
-  "links": {
-    "close-menu": "Fechar menu",
-    "documentation": "Documentação",
-    "get-in-touch": "Entrar em Contacto",
-    "get-involved": "Envolver-se",
-    "go-home": "Início",
-    "join-the-discussion": "Junte-se à Discussão",
-    "posts": "News",
-    "show-your-interest": "Show Your Interest",
-    "sponsors": "Sponsors",
-    "donate": "Donate",
-    "store": "Store",
-    "press": "Press"
+
+  "errors": {
+    "404": {
+      "title": "Página não encontrada.",
+      "explanation": "Não foi possível localizar o recurso solicitado. Por favor tente novamente."
+    }
   },
-  "socials": {
-    "forums": "Forums",
-    "github": "Github",
-    "reddit": "Reddit",
-    "mattermost": "Mattermost",
-    "twitter": "Twitter"
-  },
+
   "news": {
     "title": "News",
     "description": "Stay up-to-date on the latest from The Rocky Linux Project."
   },
+
   "press": {
     "title": "Press",
     "description": "See the latest about Rocky in the press."
   },
+
   "sponsors": {
     "title": "Sponsors",
-    "description": "We would like to thank our sponsors for their support thus far on the project."
+    "description": "We would like to thank our sponsors for their support thus far on the project.",
+    "tag": {
+      "fsponsor": "Founding Sponsor",
+      "psponsor": "Principal Sponsor"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "45drives": {
+        "name": "45Drives",
+        "description": "45Drives offers enterprise storage solutions built on powerful & robust open-source software that allows customers to benefit from the cost savings & flexibility of off-the-shelf hardware. Check them out for a fully supported data storage solution at the best cost per terabyte!"
+      },
+      "opendrives": {
+        "name": "OpenDrives",
+        "description": "OpenDrives is a global provider of enterprise-grade, hyper-scalable, network-attached-storage (NAS) solutions. We deliver the highest performing solutions for our customers - to match individual performance needs - for the most robust, complex and mission-critical projects and workflows, on-premises and into the cloud."
+      },
+      "montavista": {
+        "name": "MontaVista",
+        "description": "MontaVista Software is the leader in embedded commercial Linux, supporting MontaVista CGX, Yocto Project®, CentOS and Rocky Linux. MontaVista offers Open Source Software expertise, commercial-quality Linux distros, cost-effective maintenance and support for 10+ year life-cycles."
+      },
+      "aws": {
+        "name": "Amazon Web Services",
+        "description": "The RESF utilizes AWS to run much of the underlying infrastructure critical to the development and deployment of the services supporting Rocky Linux. From Koji builders for x86_64 and aarch64 running in EC2 to SRPM blob storage in S3, AWS is foundational to much of what we do."
+      }
+    }
+  },
+
+  "partners": {
+    "title": "Partners",
+    "description": "Partners of the RESF represent ongoing relationships of strategic importance to the Rocky Linux project. Through dedication of engineering expertise, infrastructure resources, or other means, their support is critical to our continued success and long term stability.",
+    "tag": {
+      "fpartner": "Founding Partner",
+      "ppartner": "Principal Partner"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "navercloud": {
+        "name": "NAVER Cloud",
+        "description": "NAVER Cloud Platform is a South Korean cloud service that started in 2017 under NAVER Cloud, a subsidiary of NAVER. It provides over 170 individual services in 2021 and holds various security certifications including CSA STAR GOLD, GDPR, and more. It also currently provides cloud services in 10 locations around the world."
+      },
+      "mattermost": {
+        "name": "Mattermost",
+        "description": "Mattermost is an open source messaging solution made for organizations with the highest security requirements. As big believers in the power of open source, Mattermost is thrilled to partner with RESF to help bring an enterprise-grade distribution of Linux to the tech community."
+      }
+    }
+  },
+
+  "faq": {
+    "heading": "Frequently Asked Questions",
+    "q1": {
+      "q": "Where can I download the release candidate?",
+      "a": "https://rockylinux.org/download"
+    },
+    "q2": {
+      "q": "What is a release candidate?",
+      "a": "A release candidate is a beta version of a product that has the potential to be stable.The intent of a release candidate is for the community to test and validate expected functionality of Rocky Linux and report any bugs if present."
+    },
+    "q3": {
+      "q": "Can I use the release candidate in production?",
+      "a": "Under no circumstance should you use a release candidate in a production environment. A release candidate is provided for testing and validation purposes only."
+    },
+    "q4": {
+      "q": "How can I help mirror the release candidate and future Rocky Linux releases?",
+      "a": "Please email <a href=\"mailto:mirrors@rockylinux.org\">mirrors@rockylinux.org</a> to express your interest."
+    },
+    "q5": {
+      "q": "I encountered a bug while testing the release candidate, what can I do?",
+      "a": "First, create an account using <a href=\"https://accounts.rockylinux.org/\"> Rocky Linux Account Services </a> , then head over to our <a href=\"https://bugs.rockylinux.org/\">Bugzilla server</a> to report any bugs."
+    },
+    "q6": {
+      "q": "How can I get involved with the Testing team?",
+      "a": "Please join the <a href=\"https://chat.rockylinux.org/rocky-linux/channels/testing\"> ~Testing </a> channel on our Mattermost server to get started. There’s also a testing topic on the forums for more durable conversation."
+    },
+    "q7": {
+      "q": "Where can I find the latest news about Rocky Linux?",
+      "a": "Stay tuned to our website, Twitter, LinkedIn, forums, and other platforms listed in our link directory for the latest announcements."
+    },
+    "q8": {
+      "q": "If Rocky Linux is just a respin of RHEL, what took so long for a release candidate?",
+      "a1": "If our only goal for Rocky Linux was to debrand and repackage RHEL, we would have been done much sooner. However, what we had to do differently is figure out how we could keep Rocky Linux in the hands of the community. Carefully devising this strategy ensures that Rocky Linux will never meet the same fate of CentOS.",
+      "a2": "The goal was not just to create a community managed RPM based distribution of Linux, but to ensure that it will remain freely available and always in the control of the community, much like Linux itself has. To do that required more than a build infrastructure; it required that we put in place the foundational structures that enable the community, ensuring that Rocky Linux is forever inclusive, free, and open. The infrastructure is built from the ground up by many collaborators and sponsoring organizations around composability and security compliance, providing the substrate for not only the base operating system but also an entire community of diverse interests to take part in the project."
+    },
+    "q9": {
+      "q": "If you’re not just repackaging RHEL, then what exactly are you doing?",
+      "a": "Our goal is to maintain Rocky Linux as a community-oriented distribution <i>by</i> the community, <i>for</i> the community. To do this, we are establishing the necessary organizational structures to ensure that Rocky Linux remains in the hands of the community. We want to make sure that it’s not possible for what happened to CentOS to happen to Rocky Linux."
+    },
+    "q10": {
+      "q": "How will you ensure that Rocky Linux truly remains a community enterprise operating system?",
+      "a": "First, we’ve taken steps to legally protect the Rocky Linux name. This means registering its trademarks and various associated properties to protect them from being controlled by another entity. We’ve achieved this by establishing them under the Rocky Enterprise Software Foundation (RESF). Next, we’re drafting a community charter that will define the organizational structure, objectives, values, and mission behind the legal entity that represents Rocky Linux. Critical in this charter is the establishment of principles that enable and protect the community: transparency, community involvement, open development, and independence. <strong> Rocky Linux will never be controlled, purchased, or otherwise influenced by a single entity or organization. </strong> Finally, we’re architecting and deploying the necessary infrastructure to further enable the community to contribute to Rocky Linux."
+    },
+    "q11": {
+      "q": "What infrastructure is necessary to enable the community?",
+      "a1": "We’ve established a number of teams to support the various efforts associated with developing Rocky Linux:",
+      "a2": "You can read more about this structure when it’s soon published. In order to enable collaboration across and within those teams, we needed to deploy our own chat infrastructure, forums, and website. Additionally, we’re also creating our build infrastructure, which will facilitate the development of the core operating system.",
+      "list": {
+        "community": "Community",
+        "core-inf": "Core Infrastructure",
+        "design": "Design",
+        "documentation": "Documentation",
+        "installer": "Installer",
+        "leadership": "Leadership",
+        "pkg-autob": "Package Auto-Builders",
+        "packaging": "Packaging",
+        "security": "Security",
+        "sigs": "Special Interest Groups (SIGs)",
+        "web": "Web"
+      }
+    },
+    "q12": {
+      "q": "Why does it take so much time to stand up a community and build infrastructure?",
+      "a": "It’s not terribly difficult to deploy a website, forums, or a build infrastructure in a reliable fashion. Our chat program for instance, which uses Mattermost, is distributed on a number of application servers behind a load balancer and was ready in just a couple of weeks. But it does require careful thought and planning to do it in a scalable and secure manner when you need to ensure vendor and platform agnosticity and long-term community involvement."
+    },
+    "q13": {
+      "q": "So what’s the short answer to all of this? What are some things you’re thinking about as you put Rocky Linux together?",
+      "a": "How do we carefully shepherd community trust? How do we ensure that anyone who wants to participate can not only do so immediately, but forever in the future as well? How do we engage and enable the community members who might not be as technical but want to contribute anyway? Solving for all of these challenges will take time, and we would love your help in doing so."
+    },
+    "q14": {
+      "q": "What if I have feedback or my question wasn’t answered here?",
+      "a": "Please email us: <a href=\"mailto:hello@rockylinux.org\">hello@rockylinux.org</a> and we’ll get back to you as soon as we can."
+    }
   }
 }

--- a/src/i18n/locales/ru/translation.json
+++ b/src/i18n/locales/ru/translation.json
@@ -1,73 +1,239 @@
 {
   "language": "ru",
-  "copyright": {
-    "line1": "© 2021 The Rocky Linux Project. Все права защищены.",
-    "line2": "CentOS является зарегистрированной торговой маркой компании Red Hat, Inc. Rocky Linux не связан и не одобрен Red Hat, Inc."
-  },
-  "errors": {
-    "404": {
-      "explanation": "Запрошенная страница не найдена. Пожалуйста, повторите позже.",
-      "title": "Страница не найдена."
+
+  "global": {
+
+    "copyright": {
+      "line1": "© 2021 The Rocky Linux Project. Все права защищены.",
+      "line2": "CentOS является зарегистрированной торговой маркой компании Red Hat, Inc. Rocky Linux не связан и не одобрен Red Hat, Inc."
+    },
+
+    "links": {
+      "close-menu": "Закрыть",
+      "wiki": "Wiki",
+      "get-in-touch": "Связаться",
+      "get-involved": "Принять участие",
+      "go-home": "Домашняя страница",
+      "join-the-discussion": "Обсудить",
+      "posts": "Новости",
+      "show-your-interest": "Продемонстрировать интерес",
+      "sponsors": "Спонсоры",
+      "donate": "Поддержать рублём",
+      "store": "Магазин",
+      "press": "СМИ",
+      "download": "Download",
+      "com_charter": "Community Charter",
+      "org_structure": "Organization Structure",
+      "privacy": "Privacy Policy",
+      "see-more": "See More",
+      "see-all": "See All",
+      "documentation": "Документация",
+      "bug-report": "Report a bug"
+    },
+    "socials": {
+      "forums": "Форум",
+      "github": "Github",
+      "reddit": "Reddit",
+      "mattermost": "Mattermost",
+      "twitter": "Twitter"
     }
   },
-  "faq": {
-    "a": {
-      "come-in": "Rocky Linux стремится существовать как свободная пересборка коммерческого дистрибутива, аналогично тому, как ранее разрабатывалась CentOS. Rocky Linux будет создавать выпуски после того, как они будут выпущены вышестоящим поставщиком.",
-      "downstream-partner-direction": "Проект CentOS недавно объявил об изменении стратегии для операционой системы CentOS. Так, ранее для CentOS осуществлялась пересборка пакетной базы на основе релизов вышестоящего коммерческого дистрибутива, предоставляя пользователям стабильную операционную систему корпоративного уровня. Теперь же CentOS перейдет на сборку пакетной базы с нуля, тестирование исправлений и обновлений перед включением в их в коммерческий дистрибутив, тем самым превращаясь в площадку для тестирования изменений. Кроме того, срок поддержки CentOS Linux 8 был сокращен с 31 мая 2029 года до 31 декабря 2021 года."
+
+  "homepage": {
+    "landing": {
+      "p1": {
+        "heading": "Rocky Linux",
+        "content": "Общественная инициатива по созданию готовой к работе системы Linux корпоративного уровня."
+      },
+      "p2": {
+        "heading": "Что такое Rocky Linux?",
+        "content": "Rocky Linux - это операционная система корпоративного уровня, полностью управляемая сообществом, разработанная с целью быть на 100% совместимой с ведущим корпоративным дистрибутивом Linux в Америке. Толчком к созданию Rocky Linux послужила трансформация проекта CentOS. Rocky Linux возглавляет Грегори Курцер, основатель проекта CentOS. В настоящее время Rocky Linux активно развивается сообществом, но на данный момент нет каких-либо определенных сроков формирования релиза. Всех заинтересованных просим связаться с нами используя способы связи, предложенные на сайте."
+      }
     },
-    "q": {
-      "come-in": "Какую роль играет Rocky Linux?",
-      "downstream-partner-direction": "Что значит \"трансформация проекта CentOS\"?"
-    },
-    "title": "Часто задаваемые вопросы"
+    "faq": {
+      "title": "Часто задаваемые вопросы",
+      "a": {
+        "come-in": "Rocky Linux стремится существовать как свободная пересборка коммерческого дистрибутива, аналогично тому, как ранее разрабатывалась CentOS. Rocky Linux будет создавать выпуски после того, как они будут выпущены вышестоящим поставщиком.",
+        "downstream-partner-direction": "Проект CentOS недавно объявил об изменении стратегии для операционой системы CentOS. Так, ранее для CentOS осуществлялась пересборка пакетной базы на основе релизов вышестоящего коммерческого дистрибутива, предоставляя пользователям стабильную операционную систему корпоративного уровня. Теперь же CentOS перейдет на сборку пакетной базы с нуля, тестирование исправлений и обновлений перед включением в их в коммерческий дистрибутив, тем самым превращаясь в площадку для тестирования изменений. Кроме того, срок поддержки CentOS Linux 8 был сокращен с 31 мая 2029 года до 31 декабря 2021 года."
+      },
+      "q": {
+        "come-in": "Какую роль играет Rocky Linux?",
+        "downstream-partner-direction": "Что значит \"трансформация проекта CentOS\"?"
+      }
+    }
   },
-  "landing": {
+
+  "download": {
     "p1": {
-      "content": "Общественная инициатива по созданию готовой к работе системы Linux корпоративного уровня.",
-      "heading": "Rocky Linux"
+      "heading": "Downloads",
+      "content": "Download the official release of Rocky Linux from one of our trusted mirrors."
+    },
+    "warning": "The release you can download here is a <i>Release Candidate</i> and should not be used in production. Please check our <a class=\"underline font-medium\" href=\"/faq/\">FAQ</a> for more information.",
+    "table": {
+      "architecture": "Architecture",
+      "iso": "ISOS",
+      "isos": {
+        "minimal": "Minimal",
+        "dvd": "DVD",
+        "boot": "Boot",
+        "checksum": "Checksum"
+      },
+      "packages": "Packages"
     },
     "p2": {
-      "content": "Rocky Linux - это операционная система корпоративного уровня, полностью управляемая сообществом, разработанная с целью быть на 100% совместимой с ведущим корпоративным дистрибутивом Linux в Америке. Толчком к созданию Rocky Linux послужила трансформация проекта CentOS. Rocky Linux возглавляет Грегори Курцер, основатель проекта CentOS. В настоящее время Rocky Linux активно развивается сообществом, но на данный момент нет каких-либо определенных сроков формирования релиза. Всех заинтересованных просим связаться с нами используя способы связи, предложенные на сайте.",
-      "heading": "Что такое Rocky Linux?"
+      "content": "As you download and use Rocky Linux, the Rocky Enterprise Software Foundation invites you to <a class=\"text-green-600 dark:text-green-500 font-medium\" href=\"https://chat.rockylinux.org/\">be a part of the community as a contributor</a>. There are many ways to contribute to the project, from documentation, QA, and testing to coding changes for SIGs, providing mirroring or hosting, and helping other users."
     }
   },
+
   "lang": {
     "footer": {
-      "choose-language": "Выберите язык...",
-      "literal": "Язык:"
+      "choose-language": "Выберите язык..."
     }
   },
-  "links": {
-    "close-menu": "Закрыть",
-    "documentation": "Документация",
-    "get-in-touch": "Связаться",
-    "get-involved": "Принять участие",
-    "go-home": "Домашняя страница",
-    "join-the-discussion": "Обсудить",
-    "posts": "Новости",
-    "show-your-interest": "Продемонстрировать интерес",
-    "sponsors": "Спонсоры",
-    "donate": "Поддержать рублём",
-    "store": "Магазин",
-    "press": "СМИ"
+
+  "errors": {
+    "404": {
+      "title": "Страница не найдена.",
+      "explanation": "Запрошенная страница не найдена. Пожалуйста, повторите позже."
+    }
   },
-  "socials": {
-    "forums": "Форум",
-    "github": "GitHub",
-    "reddit": "Reddit",
-    "mattermost": "Mattermost",
-    "twitter": "Twitter"
-  },
+
   "news": {
     "title": "Новости",
     "description": "Будьте в курсе последних новостей проекта Rocky Linux."
   },
+
   "press": {
     "title": "СМИ",
     "description": "Новости в прессе о Rocky."
   },
+
   "sponsors": {
     "title": "Спонсоры",
-    "description": "Наши благодарности спонсорам за их поддержку проекта."
+    "description": "Наши благодарности спонсорам за их поддержку проекта.",
+    "tag": {
+      "fsponsor": "Founding Sponsor",
+      "psponsor": "Principal Sponsor"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "45drives": {
+        "name": "45Drives",
+        "description": "45Drives offers enterprise storage solutions built on powerful & robust open-source software that allows customers to benefit from the cost savings & flexibility of off-the-shelf hardware. Check them out for a fully supported data storage solution at the best cost per terabyte!"
+      },
+      "opendrives": {
+        "name": "OpenDrives",
+        "description": "OpenDrives is a global provider of enterprise-grade, hyper-scalable, network-attached-storage (NAS) solutions. We deliver the highest performing solutions for our customers - to match individual performance needs - for the most robust, complex and mission-critical projects and workflows, on-premises and into the cloud."
+      },
+      "montavista": {
+        "name": "MontaVista",
+        "description": "MontaVista Software is the leader in embedded commercial Linux, supporting MontaVista CGX, Yocto Project®, CentOS and Rocky Linux. MontaVista offers Open Source Software expertise, commercial-quality Linux distros, cost-effective maintenance and support for 10+ year life-cycles."
+      },
+      "aws": {
+        "name": "Amazon Web Services",
+        "description": "The RESF utilizes AWS to run much of the underlying infrastructure critical to the development and deployment of the services supporting Rocky Linux. From Koji builders for x86_64 and aarch64 running in EC2 to SRPM blob storage in S3, AWS is foundational to much of what we do."
+      }
+    }
+  },
+
+  "partners": {
+    "title": "Partners",
+    "description": "Partners of the RESF represent ongoing relationships of strategic importance to the Rocky Linux project. Through dedication of engineering expertise, infrastructure resources, or other means, their support is critical to our continued success and long term stability.",
+    "tag": {
+      "fpartner": "Founding Partner",
+      "ppartner": "Principal Partner"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "navercloud": {
+        "name": "NAVER Cloud",
+        "description": "NAVER Cloud Platform is a South Korean cloud service that started in 2017 under NAVER Cloud, a subsidiary of NAVER. It provides over 170 individual services in 2021 and holds various security certifications including CSA STAR GOLD, GDPR, and more. It also currently provides cloud services in 10 locations around the world."
+      },
+      "mattermost": {
+        "name": "Mattermost",
+        "description": "Mattermost is an open source messaging solution made for organizations with the highest security requirements. As big believers in the power of open source, Mattermost is thrilled to partner with RESF to help bring an enterprise-grade distribution of Linux to the tech community."
+      }
+    }
+  },
+
+  "faq": {
+    "heading": "Frequently Asked Questions",
+    "q1": {
+      "q": "Where can I download the release candidate?",
+      "a": "https://rockylinux.org/download"
+    },
+    "q2": {
+      "q": "What is a release candidate?",
+      "a": "A release candidate is a beta version of a product that has the potential to be stable.The intent of a release candidate is for the community to test and validate expected functionality of Rocky Linux and report any bugs if present."
+    },
+    "q3": {
+      "q": "Can I use the release candidate in production?",
+      "a": "Under no circumstance should you use a release candidate in a production environment. A release candidate is provided for testing and validation purposes only."
+    },
+    "q4": {
+      "q": "How can I help mirror the release candidate and future Rocky Linux releases?",
+      "a": "Please email <a href=\"mailto:mirrors@rockylinux.org\">mirrors@rockylinux.org</a> to express your interest."
+    },
+    "q5": {
+      "q": "I encountered a bug while testing the release candidate, what can I do?",
+      "a": "First, create an account using <a href=\"https://accounts.rockylinux.org/\"> Rocky Linux Account Services </a> , then head over to our <a href=\"https://bugs.rockylinux.org/\">Bugzilla server</a> to report any bugs."
+    },
+    "q6": {
+      "q": "How can I get involved with the Testing team?",
+      "a": "Please join the <a href=\"https://chat.rockylinux.org/rocky-linux/channels/testing\"> ~Testing </a> channel on our Mattermost server to get started. There’s also a testing topic on the forums for more durable conversation."
+    },
+    "q7": {
+      "q": "Where can I find the latest news about Rocky Linux?",
+      "a": "Stay tuned to our website, Twitter, LinkedIn, forums, and other platforms listed in our link directory for the latest announcements."
+    },
+    "q8": {
+      "q": "If Rocky Linux is just a respin of RHEL, what took so long for a release candidate?",
+      "a1": "If our only goal for Rocky Linux was to debrand and repackage RHEL, we would have been done much sooner. However, what we had to do differently is figure out how we could keep Rocky Linux in the hands of the community. Carefully devising this strategy ensures that Rocky Linux will never meet the same fate of CentOS.",
+      "a2": "The goal was not just to create a community managed RPM based distribution of Linux, but to ensure that it will remain freely available and always in the control of the community, much like Linux itself has. To do that required more than a build infrastructure; it required that we put in place the foundational structures that enable the community, ensuring that Rocky Linux is forever inclusive, free, and open. The infrastructure is built from the ground up by many collaborators and sponsoring organizations around composability and security compliance, providing the substrate for not only the base operating system but also an entire community of diverse interests to take part in the project."
+    },
+    "q9": {
+      "q": "If you’re not just repackaging RHEL, then what exactly are you doing?",
+      "a": "Our goal is to maintain Rocky Linux as a community-oriented distribution <i>by</i> the community, <i>for</i> the community. To do this, we are establishing the necessary organizational structures to ensure that Rocky Linux remains in the hands of the community. We want to make sure that it’s not possible for what happened to CentOS to happen to Rocky Linux."
+    },
+    "q10": {
+      "q": "How will you ensure that Rocky Linux truly remains a community enterprise operating system?",
+      "a": "First, we’ve taken steps to legally protect the Rocky Linux name. This means registering its trademarks and various associated properties to protect them from being controlled by another entity. We’ve achieved this by establishing them under the Rocky Enterprise Software Foundation (RESF). Next, we’re drafting a community charter that will define the organizational structure, objectives, values, and mission behind the legal entity that represents Rocky Linux. Critical in this charter is the establishment of principles that enable and protect the community: transparency, community involvement, open development, and independence. <strong> Rocky Linux will never be controlled, purchased, or otherwise influenced by a single entity or organization. </strong> Finally, we’re architecting and deploying the necessary infrastructure to further enable the community to contribute to Rocky Linux."
+    },
+    "q11": {
+      "q": "What infrastructure is necessary to enable the community?",
+      "a1": "We’ve established a number of teams to support the various efforts associated with developing Rocky Linux:",
+      "a2": "You can read more about this structure when it’s soon published. In order to enable collaboration across and within those teams, we needed to deploy our own chat infrastructure, forums, and website. Additionally, we’re also creating our build infrastructure, which will facilitate the development of the core operating system.",
+      "list": {
+        "community": "Community",
+        "core-inf": "Core Infrastructure",
+        "design": "Design",
+        "documentation": "Documentation",
+        "installer": "Installer",
+        "leadership": "Leadership",
+        "pkg-autob": "Package Auto-Builders",
+        "packaging": "Packaging",
+        "security": "Security",
+        "sigs": "Special Interest Groups (SIGs)",
+        "web": "Web"
+      }
+    },
+    "q12": {
+      "q": "Why does it take so much time to stand up a community and build infrastructure?",
+      "a": "It’s not terribly difficult to deploy a website, forums, or a build infrastructure in a reliable fashion. Our chat program for instance, which uses Mattermost, is distributed on a number of application servers behind a load balancer and was ready in just a couple of weeks. But it does require careful thought and planning to do it in a scalable and secure manner when you need to ensure vendor and platform agnosticity and long-term community involvement."
+    },
+    "q13": {
+      "q": "So what’s the short answer to all of this? What are some things you’re thinking about as you put Rocky Linux together?",
+      "a": "How do we carefully shepherd community trust? How do we ensure that anyone who wants to participate can not only do so immediately, but forever in the future as well? How do we engage and enable the community members who might not be as technical but want to contribute anyway? Solving for all of these challenges will take time, and we would love your help in doing so."
+    },
+    "q14": {
+      "q": "What if I have feedback or my question wasn’t answered here?",
+      "a": "Please email us: <a href=\"mailto:hello@rockylinux.org\">hello@rockylinux.org</a> and we’ll get back to you as soon as we can."
+    }
   }
 }

--- a/src/i18n/locales/sv/translation.json
+++ b/src/i18n/locales/sv/translation.json
@@ -1,72 +1,241 @@
 {
   "language": "sv",
-  "copyright": {
-    "line1": "© 2021 Rocky Linux-projektet. Alla rättigheter förbehållna.",
-    "line2": "CentOS är ett registrerat varumärke som tillhör Red Hat, Inc. Rocky Linux-projektet är inte anslutet till eller godkänt av Red Hat, Inc."
-  },
-  "errors": {
-    "404": {
-      "explanation": "Den sida du försökte nå kunde inte hittas. Var god försök igen.",
-      "title": "Sidan hittades inte."
+
+  "global": {
+
+    "copyright": {
+      "line1": "© 2021 Rocky Linux-projektet. Alla rättigheter förbehållna.",
+      "line2": "CentOS är ett registrerat varumärke som tillhör Red Hat, Inc. Rocky Linux-projektet är inte anslutet till eller godkänt av Red Hat, Inc."
+    },
+
+    "links": {
+      "close-menu": "Stäng menyn",
+      "wiki": "Wiki",
+      "get-in-touch": "Kontakta oss",
+      "get-involved": "Bli involverad",
+      "go-home": "Hem",
+      "join-the-discussion": "Gå med i diskussionen",
+      "posts": "News",
+      "show-your-interest": "Show Your Interest",
+      "sponsors": "Sponsors",
+      "partners": "Partners",
+      "status": "Service Status",
+      "donate": "Donate",
+      "store": "Store",
+      "press": "Press",
+      "download": "Download",
+      "com_charter": "Community Charter",
+      "org_structure": "Organization Structure",
+      "privacy": "Privacy Policy",
+      "see-more": "See More",
+      "see-all": "See All",
+      "documentation": "Dokumentation",
+      "bug-report": "Report a bug"
+    },
+    "socials": {
+      "forums": "Forums",
+      "github": "Github",
+      "reddit": "Reddit",
+      "mattermost": "Mattermost",
+      "twitter": "Twitter"
     }
   },
-  "faq": {
-    "a": {
-      "come-in": "Rocky Linux mål är att fungera som ett nedströmsbygge som CentOS har gjort tidigare, att bygga utgåvor efter de har lagts till av uppströmsleverantören, inte före.",
-      "downstream-partner-direction": "CentOS-projektet tillkännagav nyligen ett skifte i strategi för CentOS. Medan CentOS tidigare existerade som ett nedströmsbygge av dess uppströmsleverantör (det tar emot korrigeringar och uppdateringar efter att uppströmsleverantören gör det) kommer den att flyttas till att bara bli ett uppströmsbygge (testa korrigeringar och uppdateringar innan de inkluderas i uppströmsleverantören). Dessutom har stödet för CentOS Linux 8 förkortats, från 31 maj 2029 till 31 december 2021."
+
+  "homepage": {
+    "landing": {
+      "p1": {
+        "heading": "Rocky Linux",
+        "content": "En gemenskapsdriven insats för att ge dig en produktionsklar Linux i företagsklass."
+      },
+      "p2": {
+        "heading": "Vad är Rocky Linux Projektet?",
+        "content": "Rocky Linux är ett gemenskapsdrivet operativsystem utformat för att vara 100% bugg-för-bugg-kompatibelt med Amerikas främsta företagsklass Linux distribution nu när dess nedströms partner har skiftat inriktning. Det är under intensiv utveckling av gemenskapen. Rocky Linux leds av Gregory Kurtzer, grundare av CentOS-projektet. Det finns inget datum satt för första utgåvan. Bidragsgivare uppmanas att nå oss med hjälp av de kommunikationsalternativ som erbjuds på denna webbplats."
+      }
     },
-    "q": {
-      "come-in": "Så var kommer Rocky Linux in?",
-      "downstream-partner-direction": "Vad menar ni med att \"dess nedströmspartner har skiftat riktning?\""
-    },
-    "title": "Vanliga frågor"
+    "faq": {
+      "title": "Vanliga frågor",
+      "a": {
+        "come-in": "Rocky Linux mål är att fungera som ett nedströmsbygge som CentOS har gjort tidigare, att bygga utgåvor efter de har lagts till av uppströmsleverantören, inte före.",
+        "downstream-partner-direction": "CentOS-projektet tillkännagav nyligen ett skifte i strategi för CentOS. Medan CentOS tidigare existerade som ett nedströmsbygge av dess uppströmsleverantör (det tar emot korrigeringar och uppdateringar efter att uppströmsleverantören gör det) kommer den att flyttas till att bara bli ett uppströmsbygge (testa korrigeringar och uppdateringar innan de inkluderas i uppströmsleverantören). Dessutom har stödet för CentOS Linux 8 förkortats, från 31 maj 2029 till 31 december 2021."
+      },
+      "q": {
+        "come-in": "Så var kommer Rocky Linux in?",
+        "downstream-partner-direction": "Vad menar ni med att \"dess nedströmspartner har skiftat riktning?\""
+      }
+    }
   },
-  "landing": {
+
+  "download": {
     "p1": {
-      "content": "En gemenskapsdriven insats för att ge dig en produktionsklar Linux i företagsklass.",
-      "heading": "Rocky Linux"
+      "heading": "Downloads",
+      "content": "Download the official release of Rocky Linux from one of our trusted mirrors."
+    },
+    "warning": "The release you can download here is a <i>Release Candidate</i> and should not be used in production. Please check our <a class=\"underline font-medium\" href=\"/faq/\">FAQ</a> for more information.",
+    "table": {
+      "architecture": "Architecture",
+      "iso": "ISOS",
+      "isos": {
+        "minimal": "Minimal",
+        "dvd": "DVD",
+        "boot": "Boot",
+        "checksum": "Checksum"
+      },
+      "packages": "Packages"
     },
     "p2": {
-      "content": "Rocky Linux är ett gemenskapsdrivet operativsystem utformat för att vara 100% bugg-för-bugg-kompatibelt med Amerikas främsta företagsklass Linux distribution nu när dess nedströms partner har skiftat inriktning. Det är under intensiv utveckling av gemenskapen. Rocky Linux leds av Gregory Kurtzer, grundare av CentOS-projektet. Det finns inget datum satt för första utgåvan. Bidragsgivare uppmanas att nå oss med hjälp av de kommunikationsalternativ som erbjuds på denna webbplats.",
-      "heading": "Vad är Rocky Linux Projektet?"
+      "content": "As you download and use Rocky Linux, the Rocky Enterprise Software Foundation invites you to <a class=\"text-green-600 dark:text-green-500 font-medium\" href=\"https://chat.rockylinux.org/\">be a part of the community as a contributor</a>. There are many ways to contribute to the project, from documentation, QA, and testing to coding changes for SIGs, providing mirroring or hosting, and helping other users."
     }
   },
+
   "lang": {
     "footer": {
       "choose-language": "Välj språk..."
     }
   },
-  "links": {
-    "close-menu": "Stäng menyn",
-    "documentation": "Dokumentation",
-    "get-in-touch": "Kontakta oss",
-    "get-involved": "Bli involverad",
-    "go-home": "Hem",
-    "join-the-discussion": "Gå med i diskussionen",
-    "posts": "News",
-    "show-your-interest": "Show Your Interest",
-    "sponsors": "Sponsors",
-    "donate": "Donate",
-    "store": "Store",
-    "press": "Press"
+
+  "errors": {
+    "404": {
+      "title": "Sidan hittades inte.",
+      "explanation": "Den sida du försökte nå kunde inte hittas. Var god försök igen."
+    }
   },
-  "socials": {
-    "forums": "Forum",
-    "github": "Github",
-    "reddit": "Reddit",
-    "mattermost": "Mattermost",
-    "twitter": "Twitter"
-  },
+
   "news": {
     "title": "News",
     "description": "Stay up-to-date on the latest from The Rocky Linux Project."
   },
+
   "press": {
     "title": "Press",
     "description": "See the latest about Rocky in the press."
   },
+
   "sponsors": {
     "title": "Sponsors",
-    "description": "We would like to thank our sponsors for their support thus far on the project."
+    "description": "We would like to thank our sponsors for their support thus far on the project.",
+    "tag": {
+      "fsponsor": "Founding Sponsor",
+      "psponsor": "Principal Sponsor"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "45drives": {
+        "name": "45Drives",
+        "description": "45Drives offers enterprise storage solutions built on powerful & robust open-source software that allows customers to benefit from the cost savings & flexibility of off-the-shelf hardware. Check them out for a fully supported data storage solution at the best cost per terabyte!"
+      },
+      "opendrives": {
+        "name": "OpenDrives",
+        "description": "OpenDrives is a global provider of enterprise-grade, hyper-scalable, network-attached-storage (NAS) solutions. We deliver the highest performing solutions for our customers - to match individual performance needs - for the most robust, complex and mission-critical projects and workflows, on-premises and into the cloud."
+      },
+      "montavista": {
+        "name": "MontaVista",
+        "description": "MontaVista Software is the leader in embedded commercial Linux, supporting MontaVista CGX, Yocto Project®, CentOS and Rocky Linux. MontaVista offers Open Source Software expertise, commercial-quality Linux distros, cost-effective maintenance and support for 10+ year life-cycles."
+      },
+      "aws": {
+        "name": "Amazon Web Services",
+        "description": "The RESF utilizes AWS to run much of the underlying infrastructure critical to the development and deployment of the services supporting Rocky Linux. From Koji builders for x86_64 and aarch64 running in EC2 to SRPM blob storage in S3, AWS is foundational to much of what we do."
+      }
+    }
+  },
+
+  "partners": {
+    "title": "Partners",
+    "description": "Partners of the RESF represent ongoing relationships of strategic importance to the Rocky Linux project. Through dedication of engineering expertise, infrastructure resources, or other means, their support is critical to our continued success and long term stability.",
+    "tag": {
+      "fpartner": "Founding Partner",
+      "ppartner": "Principal Partner"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "navercloud": {
+        "name": "NAVER Cloud",
+        "description": "NAVER Cloud Platform is a South Korean cloud service that started in 2017 under NAVER Cloud, a subsidiary of NAVER. It provides over 170 individual services in 2021 and holds various security certifications including CSA STAR GOLD, GDPR, and more. It also currently provides cloud services in 10 locations around the world."
+      },
+      "mattermost": {
+        "name": "Mattermost",
+        "description": "Mattermost is an open source messaging solution made for organizations with the highest security requirements. As big believers in the power of open source, Mattermost is thrilled to partner with RESF to help bring an enterprise-grade distribution of Linux to the tech community."
+      }
+    }
+  },
+
+  "faq": {
+    "heading": "Frequently Asked Questions",
+    "q1": {
+      "q": "Where can I download the release candidate?",
+      "a": "https://rockylinux.org/download"
+    },
+    "q2": {
+      "q": "What is a release candidate?",
+      "a": "A release candidate is a beta version of a product that has the potential to be stable.The intent of a release candidate is for the community to test and validate expected functionality of Rocky Linux and report any bugs if present."
+    },
+    "q3": {
+      "q": "Can I use the release candidate in production?",
+      "a": "Under no circumstance should you use a release candidate in a production environment. A release candidate is provided for testing and validation purposes only."
+    },
+    "q4": {
+      "q": "How can I help mirror the release candidate and future Rocky Linux releases?",
+      "a": "Please email <a href=\"mailto:mirrors@rockylinux.org\">mirrors@rockylinux.org</a> to express your interest."
+    },
+    "q5": {
+      "q": "I encountered a bug while testing the release candidate, what can I do?",
+      "a": "First, create an account using <a href=\"https://accounts.rockylinux.org/\"> Rocky Linux Account Services </a> , then head over to our <a href=\"https://bugs.rockylinux.org/\">Bugzilla server</a> to report any bugs."
+    },
+    "q6": {
+      "q": "How can I get involved with the Testing team?",
+      "a": "Please join the <a href=\"https://chat.rockylinux.org/rocky-linux/channels/testing\"> ~Testing </a> channel on our Mattermost server to get started. There’s also a testing topic on the forums for more durable conversation."
+    },
+    "q7": {
+      "q": "Where can I find the latest news about Rocky Linux?",
+      "a": "Stay tuned to our website, Twitter, LinkedIn, forums, and other platforms listed in our link directory for the latest announcements."
+    },
+    "q8": {
+      "q": "If Rocky Linux is just a respin of RHEL, what took so long for a release candidate?",
+      "a1": "If our only goal for Rocky Linux was to debrand and repackage RHEL, we would have been done much sooner. However, what we had to do differently is figure out how we could keep Rocky Linux in the hands of the community. Carefully devising this strategy ensures that Rocky Linux will never meet the same fate of CentOS.",
+      "a2": "The goal was not just to create a community managed RPM based distribution of Linux, but to ensure that it will remain freely available and always in the control of the community, much like Linux itself has. To do that required more than a build infrastructure; it required that we put in place the foundational structures that enable the community, ensuring that Rocky Linux is forever inclusive, free, and open. The infrastructure is built from the ground up by many collaborators and sponsoring organizations around composability and security compliance, providing the substrate for not only the base operating system but also an entire community of diverse interests to take part in the project."
+    },
+    "q9": {
+      "q": "If you’re not just repackaging RHEL, then what exactly are you doing?",
+      "a": "Our goal is to maintain Rocky Linux as a community-oriented distribution <i>by</i> the community, <i>for</i> the community. To do this, we are establishing the necessary organizational structures to ensure that Rocky Linux remains in the hands of the community. We want to make sure that it’s not possible for what happened to CentOS to happen to Rocky Linux."
+    },
+    "q10": {
+      "q": "How will you ensure that Rocky Linux truly remains a community enterprise operating system?",
+      "a": "First, we’ve taken steps to legally protect the Rocky Linux name. This means registering its trademarks and various associated properties to protect them from being controlled by another entity. We’ve achieved this by establishing them under the Rocky Enterprise Software Foundation (RESF). Next, we’re drafting a community charter that will define the organizational structure, objectives, values, and mission behind the legal entity that represents Rocky Linux. Critical in this charter is the establishment of principles that enable and protect the community: transparency, community involvement, open development, and independence. <strong> Rocky Linux will never be controlled, purchased, or otherwise influenced by a single entity or organization. </strong> Finally, we’re architecting and deploying the necessary infrastructure to further enable the community to contribute to Rocky Linux."
+    },
+    "q11": {
+      "q": "What infrastructure is necessary to enable the community?",
+      "a1": "We’ve established a number of teams to support the various efforts associated with developing Rocky Linux:",
+      "a2": "You can read more about this structure when it’s soon published. In order to enable collaboration across and within those teams, we needed to deploy our own chat infrastructure, forums, and website. Additionally, we’re also creating our build infrastructure, which will facilitate the development of the core operating system.",
+      "list": {
+        "community": "Community",
+        "core-inf": "Core Infrastructure",
+        "design": "Design",
+        "documentation": "Documentation",
+        "installer": "Installer",
+        "leadership": "Leadership",
+        "pkg-autob": "Package Auto-Builders",
+        "packaging": "Packaging",
+        "security": "Security",
+        "sigs": "Special Interest Groups (SIGs)",
+        "web": "Web"
+      }
+    },
+    "q12": {
+      "q": "Why does it take so much time to stand up a community and build infrastructure?",
+      "a": "It’s not terribly difficult to deploy a website, forums, or a build infrastructure in a reliable fashion. Our chat program for instance, which uses Mattermost, is distributed on a number of application servers behind a load balancer and was ready in just a couple of weeks. But it does require careful thought and planning to do it in a scalable and secure manner when you need to ensure vendor and platform agnosticity and long-term community involvement."
+    },
+    "q13": {
+      "q": "So what’s the short answer to all of this? What are some things you’re thinking about as you put Rocky Linux together?",
+      "a": "How do we carefully shepherd community trust? How do we ensure that anyone who wants to participate can not only do so immediately, but forever in the future as well? How do we engage and enable the community members who might not be as technical but want to contribute anyway? Solving for all of these challenges will take time, and we would love your help in doing so."
+    },
+    "q14": {
+      "q": "What if I have feedback or my question wasn’t answered here?",
+      "a": "Please email us: <a href=\"mailto:hello@rockylinux.org\">hello@rockylinux.org</a> and we’ll get back to you as soon as we can."
+    }
   }
 }

--- a/src/i18n/locales/tr/translation.json
+++ b/src/i18n/locales/tr/translation.json
@@ -1,1 +1,239 @@
-{"language":"tr","copyright":{"line1":"© 2021 Rocky Linux Projesi. Tüm hakları saklıdır.","line2":"Red Hat ve CentOS, Red Hat, Inc.'in veya yan kuruluşlarının ticari veya tescilli ticari markalarıdır. Rocky Linux Projesi, CentOS ve Red Hat, Inc.'e bağlı değildir ve Red Hat, Inc. tarafından desteklenmemektedir ve sponsorluğu altında değildir."},"errors":{"404":{"explanation":"İstenilen kaynağa erişilemedi. Lütfen tekrar deneyin.","title":"Sayfa bulunamadı."}},"faq":{"a":{"come-in":"Rocky Linux, CentOS'un geçmişte yaptığı gibi downstream bir versiyon olmayı hedefliyor. Sürümler upstream karşılığına yenilikler eklendikten sonra çıkacak, önce değil.","downstream-partner-direction":"CentOS projesi geçtiğimiz günlerde CentOS için stratejide bir değişiklik duyurdu. Geçmişte CentOS, Enterprise Linux'in bir downstream (çıkan güncellemeleri ve güvenlik yamalarını upstream versiyonu aldıktan sonra alan) versiyonu olarak kullanılıyordu fakat Enterprise Linux'un upstream (çıkan güncellemeleri ve güvenlik yamalarının denendiği) versiyonu olma yönünde bir değişiklik yaşadı. Ek olarak, CentOS Linux 8'e verilecek desteğin son tarihi 31 Mayıs 2029'dan 31 Aralık 2021'e çekildi."},"q":{"come-in":"Peki Rocky Linux nereden geliyor?","downstream-partner-direction":"\"Downstream partneri yön değiştirdi.\" ne anlama geliyor?"},"title":"Sıkça Sorulan Sorular"},"landing":{"p1":{"content":"Topluluk odaklı, Kurumsal kullanıma hazır işletim sistemi.","heading":"Rocky Linux"},"p2":{"content":"Rocky Linux, topluluk tarafından oluşturulan ve karşılığı downstream olmayı bıraktıktan sonra Enterprise Linux ile 100% bug-for-bug şekilde uyumlu olması için dizayn edilmiş bir işletim sistemidir. Topluluk tarafından yoğun bir şekilde geliştirilmektedir. Rocky Linux, CentOS projesinin kurucusu Gregory Kurtzer tarafından yönetiliyor. Sürüm için tahmini çıkış zamanı yoktur. Katkıda bulunanlardan, bu sitede sunulan iletişim seçeneklerini kullanarak ulaşmaları istenir.","heading":"Rocky Linux Projesi Nedir?"}},"lang":{"footer":{"choose-language":"Dilinizi Seçiniz..."}},"links":{"close-menu":"Menüyü Kapat","documentation":"Dokümantasyon","get-in-touch":"İletişime Geçin","get-involved":"Bize Katılın","go-home":"Ana Sayfa","join-the-discussion":"Tartışmaya Katılın","posts":"Haberler","show-your-interest":"İlginizi Gösterin","sponsors":"Sponsorlar","donate":"Bağış","store":"Mağaza","press":"Basın"},"socials":{"forums":"Forumlar","github":"Github","reddit":"Reddit","mattermost":"Mattermost","twitter":"Twitter"},"news":{"title":"Haberler","description":"Rocky Linux Projesi ile ilgili en son gelişmelerden haberdar olun."},"press":{"title":"Basın","description":"Basında Rocky hakkındaki son haberlere ulaşın."},"sponsors":{"title":"Sponsorlar","description":"Sponsorlarımıza şu ana kadar projeye verdikleri destek için teşekkür ederiz."}}
+{
+  "language": "tr",
+
+  "global": {
+
+    "copyright": {
+      "line1": "© 2021 Rocky Linux Projesi. Tüm hakları saklıdır.",
+      "line2": "Red Hat ve CentOS, Red Hat, Inc.'in veya yan kuruluşlarının ticari veya tescilli ticari markalarıdır. Rocky Linux Projesi, CentOS ve Red Hat, Inc.'e bağlı değildir ve Red Hat, Inc. tarafından desteklenmemektedir ve sponsorluğu altında değildir."
+    },
+
+    "links": {
+      "close-menu": "Menüyü Kapat",
+      "wiki": "Wiki",
+      "get-in-touch": "İletişime Geçin",
+      "get-involved": "Bize Katılın",
+      "go-home": "Ana Sayfa",
+      "join-the-discussion": "Tartışmaya Katılın",
+      "posts": "Haberler",
+      "show-your-interest": "İlginizi Gösterin",
+      "sponsors": "Sponsorlar",
+      "donate": "Bağış",
+      "store": "Mağaza",
+      "press": "Basın",
+      "download": "Download",
+      "com_charter": "Community Charter",
+      "org_structure": "Organization Structure",
+      "privacy": "Privacy Policy",
+      "see-more": "See More",
+      "see-all": "See All",
+      "documentation": "Dokümantasyon",
+      "bug-report": "Report a bug"
+    },
+    "socials": {
+      "forums": "Forumlar",
+      "github": "Github",
+      "reddit": "Reddit",
+      "mattermost": "Mattermost",
+      "twitter": "Twitter"
+    }
+  },
+
+  "homepage": {
+    "landing": {
+      "p1": {
+        "heading": "Rocky Linux",
+        "content": "Topluluk odaklı, Kurumsal kullanıma hazır işletim sistemi."
+      },
+      "p2": {
+        "heading": "Rocky Linux Projesi Nedir?",
+        "content": "Rocky Linux, topluluk tarafından oluşturulan ve karşılığı downstream olmayı bıraktıktan sonra Enterprise Linux ile 100% bug-for-bug şekilde uyumlu olması için dizayn edilmiş bir işletim sistemidir. Topluluk tarafından yoğun bir şekilde geliştirilmektedir. Rocky Linux, CentOS projesinin kurucusu Gregory Kurtzer tarafından yönetiliyor. Sürüm için tahmini çıkış zamanı yoktur. Katkıda bulunanlardan, bu sitede sunulan iletişim seçeneklerini kullanarak ulaşmaları istenir."
+      }
+    },
+    "faq": {
+      "title": "Sıkça Sorulan Sorular",
+      "a": {
+        "come-in": "Rocky Linux, CentOS'un geçmişte yaptığı gibi downstream bir versiyon olmayı hedefliyor. Sürümler upstream karşılığına yenilikler eklendikten sonra çıkacak, önce değil.",
+        "downstream-partner-direction": "CentOS projesi geçtiğimiz günlerde CentOS için stratejide bir değişiklik duyurdu. Geçmişte CentOS, Enterprise Linux'in bir downstream (çıkan güncellemeleri ve güvenlik yamalarını upstream versiyonu aldıktan sonra alan) versiyonu olarak kullanılıyordu fakat Enterprise Linux'un upstream (çıkan güncellemeleri ve güvenlik yamalarının denendiği) versiyonu olma yönünde bir değişiklik yaşadı. Ek olarak, CentOS Linux 8'e verilecek desteğin son tarihi 31 Mayıs 2029'dan 31 Aralık 2021'e çekildi."
+      },
+      "q": {
+        "come-in": "Peki Rocky Linux nereden geliyor?",
+        "downstream-partner-direction": "\"Downstream partneri yön değiştirdi.\" ne anlama geliyor?"
+      }
+    }
+  },
+
+  "download": {
+    "p1": {
+      "heading": "Downloads",
+      "content": "Download the official release of Rocky Linux from one of our trusted mirrors."
+    },
+    "warning": "The release you can download here is a <i>Release Candidate</i> and should not be used in production. Please check our <a class=\"underline font-medium\" href=\"/faq/\">FAQ</a> for more information.",
+    "table": {
+      "architecture": "Architecture",
+      "iso": "ISOS",
+      "isos": {
+        "minimal": "Minimal",
+        "dvd": "DVD",
+        "boot": "Boot",
+        "checksum": "Checksum"
+      },
+      "packages": "Packages"
+    },
+    "p2": {
+      "content": "As you download and use Rocky Linux, the Rocky Enterprise Software Foundation invites you to <a class=\"text-green-600 dark:text-green-500 font-medium\" href=\"https://chat.rockylinux.org/\">be a part of the community as a contributor</a>. There are many ways to contribute to the project, from documentation, QA, and testing to coding changes for SIGs, providing mirroring or hosting, and helping other users."
+    }
+  },
+
+  "lang": {
+    "footer": {
+      "choose-language": "Dilinizi Seçiniz..."
+    }
+  },
+
+  "errors": {
+    "404": {
+      "title": "Sayfa bulunamadı.",
+      "explanation": "İstenilen kaynağa erişilemedi. Lütfen tekrar deneyin."
+    }
+  },
+
+  "news": {
+    "title": "Haberler",
+    "description": "Rocky Linux Projesi ile ilgili en son gelişmelerden haberdar olun."
+  },
+
+  "press": {
+    "title": "Basın",
+    "description": "Basında Rocky hakkındaki son haberlere ulaşın."
+  },
+
+  "sponsors": {
+    "title": "Sponsorlar",
+    "description": "Sponsorlarımıza şu ana kadar projeye verdikleri destek için teşekkür ederiz.",
+    "tag": {
+      "fsponsor": "Founding Sponsor",
+      "psponsor": "Principal Sponsor"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "45drives": {
+        "name": "45Drives",
+        "description": "45Drives offers enterprise storage solutions built on powerful & robust open-source software that allows customers to benefit from the cost savings & flexibility of off-the-shelf hardware. Check them out for a fully supported data storage solution at the best cost per terabyte!"
+      },
+      "opendrives": {
+        "name": "OpenDrives",
+        "description": "OpenDrives is a global provider of enterprise-grade, hyper-scalable, network-attached-storage (NAS) solutions. We deliver the highest performing solutions for our customers - to match individual performance needs - for the most robust, complex and mission-critical projects and workflows, on-premises and into the cloud."
+      },
+      "montavista": {
+        "name": "MontaVista",
+        "description": "MontaVista Software is the leader in embedded commercial Linux, supporting MontaVista CGX, Yocto Project®, CentOS and Rocky Linux. MontaVista offers Open Source Software expertise, commercial-quality Linux distros, cost-effective maintenance and support for 10+ year life-cycles."
+      },
+      "aws": {
+        "name": "Amazon Web Services",
+        "description": "The RESF utilizes AWS to run much of the underlying infrastructure critical to the development and deployment of the services supporting Rocky Linux. From Koji builders for x86_64 and aarch64 running in EC2 to SRPM blob storage in S3, AWS is foundational to much of what we do."
+      }
+    }
+  },
+
+  "partners": {
+    "title": "Partners",
+    "description": "Partners of the RESF represent ongoing relationships of strategic importance to the Rocky Linux project. Through dedication of engineering expertise, infrastructure resources, or other means, their support is critical to our continued success and long term stability.",
+    "tag": {
+      "fpartner": "Founding Partner",
+      "ppartner": "Principal Partner"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "navercloud": {
+        "name": "NAVER Cloud",
+        "description": "NAVER Cloud Platform is a South Korean cloud service that started in 2017 under NAVER Cloud, a subsidiary of NAVER. It provides over 170 individual services in 2021 and holds various security certifications including CSA STAR GOLD, GDPR, and more. It also currently provides cloud services in 10 locations around the world."
+      },
+      "mattermost": {
+        "name": "Mattermost",
+        "description": "Mattermost is an open source messaging solution made for organizations with the highest security requirements. As big believers in the power of open source, Mattermost is thrilled to partner with RESF to help bring an enterprise-grade distribution of Linux to the tech community."
+      }
+    }
+  },
+
+  "faq": {
+    "heading": "Frequently Asked Questions",
+    "q1": {
+      "q": "Where can I download the release candidate?",
+      "a": "https://rockylinux.org/download"
+    },
+    "q2": {
+      "q": "What is a release candidate?",
+      "a": "A release candidate is a beta version of a product that has the potential to be stable.The intent of a release candidate is for the community to test and validate expected functionality of Rocky Linux and report any bugs if present."
+    },
+    "q3": {
+      "q": "Can I use the release candidate in production?",
+      "a": "Under no circumstance should you use a release candidate in a production environment. A release candidate is provided for testing and validation purposes only."
+    },
+    "q4": {
+      "q": "How can I help mirror the release candidate and future Rocky Linux releases?",
+      "a": "Please email <a href=\"mailto:mirrors@rockylinux.org\">mirrors@rockylinux.org</a> to express your interest."
+    },
+    "q5": {
+      "q": "I encountered a bug while testing the release candidate, what can I do?",
+      "a": "First, create an account using <a href=\"https://accounts.rockylinux.org/\"> Rocky Linux Account Services </a> , then head over to our <a href=\"https://bugs.rockylinux.org/\">Bugzilla server</a> to report any bugs."
+    },
+    "q6": {
+      "q": "How can I get involved with the Testing team?",
+      "a": "Please join the <a href=\"https://chat.rockylinux.org/rocky-linux/channels/testing\"> ~Testing </a> channel on our Mattermost server to get started. There’s also a testing topic on the forums for more durable conversation."
+    },
+    "q7": {
+      "q": "Where can I find the latest news about Rocky Linux?",
+      "a": "Stay tuned to our website, Twitter, LinkedIn, forums, and other platforms listed in our link directory for the latest announcements."
+    },
+    "q8": {
+      "q": "If Rocky Linux is just a respin of RHEL, what took so long for a release candidate?",
+      "a1": "If our only goal for Rocky Linux was to debrand and repackage RHEL, we would have been done much sooner. However, what we had to do differently is figure out how we could keep Rocky Linux in the hands of the community. Carefully devising this strategy ensures that Rocky Linux will never meet the same fate of CentOS.",
+      "a2": "The goal was not just to create a community managed RPM based distribution of Linux, but to ensure that it will remain freely available and always in the control of the community, much like Linux itself has. To do that required more than a build infrastructure; it required that we put in place the foundational structures that enable the community, ensuring that Rocky Linux is forever inclusive, free, and open. The infrastructure is built from the ground up by many collaborators and sponsoring organizations around composability and security compliance, providing the substrate for not only the base operating system but also an entire community of diverse interests to take part in the project."
+    },
+    "q9": {
+      "q": "If you’re not just repackaging RHEL, then what exactly are you doing?",
+      "a": "Our goal is to maintain Rocky Linux as a community-oriented distribution <i>by</i> the community, <i>for</i> the community. To do this, we are establishing the necessary organizational structures to ensure that Rocky Linux remains in the hands of the community. We want to make sure that it’s not possible for what happened to CentOS to happen to Rocky Linux."
+    },
+    "q10": {
+      "q": "How will you ensure that Rocky Linux truly remains a community enterprise operating system?",
+      "a": "First, we’ve taken steps to legally protect the Rocky Linux name. This means registering its trademarks and various associated properties to protect them from being controlled by another entity. We’ve achieved this by establishing them under the Rocky Enterprise Software Foundation (RESF). Next, we’re drafting a community charter that will define the organizational structure, objectives, values, and mission behind the legal entity that represents Rocky Linux. Critical in this charter is the establishment of principles that enable and protect the community: transparency, community involvement, open development, and independence. <strong> Rocky Linux will never be controlled, purchased, or otherwise influenced by a single entity or organization. </strong> Finally, we’re architecting and deploying the necessary infrastructure to further enable the community to contribute to Rocky Linux."
+    },
+    "q11": {
+      "q": "What infrastructure is necessary to enable the community?",
+      "a1": "We’ve established a number of teams to support the various efforts associated with developing Rocky Linux:",
+      "a2": "You can read more about this structure when it’s soon published. In order to enable collaboration across and within those teams, we needed to deploy our own chat infrastructure, forums, and website. Additionally, we’re also creating our build infrastructure, which will facilitate the development of the core operating system.",
+      "list": {
+        "community": "Community",
+        "core-inf": "Core Infrastructure",
+        "design": "Design",
+        "documentation": "Documentation",
+        "installer": "Installer",
+        "leadership": "Leadership",
+        "pkg-autob": "Package Auto-Builders",
+        "packaging": "Packaging",
+        "security": "Security",
+        "sigs": "Special Interest Groups (SIGs)",
+        "web": "Web"
+      }
+    },
+    "q12": {
+      "q": "Why does it take so much time to stand up a community and build infrastructure?",
+      "a": "It’s not terribly difficult to deploy a website, forums, or a build infrastructure in a reliable fashion. Our chat program for instance, which uses Mattermost, is distributed on a number of application servers behind a load balancer and was ready in just a couple of weeks. But it does require careful thought and planning to do it in a scalable and secure manner when you need to ensure vendor and platform agnosticity and long-term community involvement."
+    },
+    "q13": {
+      "q": "So what’s the short answer to all of this? What are some things you’re thinking about as you put Rocky Linux together?",
+      "a": "How do we carefully shepherd community trust? How do we ensure that anyone who wants to participate can not only do so immediately, but forever in the future as well? How do we engage and enable the community members who might not be as technical but want to contribute anyway? Solving for all of these challenges will take time, and we would love your help in doing so."
+    },
+    "q14": {
+      "q": "What if I have feedback or my question wasn’t answered here?",
+      "a": "Please email us: <a href=\"mailto:hello@rockylinux.org\">hello@rockylinux.org</a> and we’ll get back to you as soon as we can."
+    }
+  }
+}

--- a/src/i18n/locales/uk/translation.json
+++ b/src/i18n/locales/uk/translation.json
@@ -1,72 +1,241 @@
 {
   "language": "uk",
-  "copyright": {
-    "line1": "© 2021 Проєкт Rocky Linux. Всі права застережено.",
-    "line2": "CentOS є зареєстрованою торговою маркою Red Hat, Inc. Проєкт Rocky Linux не афілійований з Red Hat, Inc. та не схвалений Red Hat, Inc."
-  },
-  "errors": {
-    "404": {
-      "explanation": "Запитуваний ресурс не було знайдено. Будь ласка спробуйте ще раз.",
-      "title": "Сторінку не знайдено."
+
+  "global": {
+
+    "copyright": {
+      "line1": "© 2021 Проєкт Rocky Linux. Всі права застережено.",
+      "line2": "CentOS є зареєстрованою торговою маркою Red Hat, Inc. Проєкт Rocky Linux не афілійований з Red Hat, Inc. та не схвалений Red Hat, Inc."
+    },
+
+    "links": {
+      "close-menu": "Закрити меню",
+      "wiki": "Wiki",
+      "get-in-touch": "Контакти",
+      "get-involved": "Долучитись",
+      "go-home": "Домашня сторінка",
+      "join-the-discussion": "Долучитись до дискусії",
+      "posts": "News",
+      "show-your-interest": "Show Your Interest",
+      "sponsors": "Sponsors",
+      "partners": "Partners",
+      "status": "Service Status",
+      "donate": "Donate",
+      "store": "Store",
+      "press": "Press",
+      "download": "Download",
+      "com_charter": "Community Charter",
+      "org_structure": "Organization Structure",
+      "privacy": "Privacy Policy",
+      "see-more": "See More",
+      "see-all": "See All",
+      "documentation": "Документація",
+      "bug-report": "Report a bug"
+    },
+    "socials": {
+      "forums": "Forums",
+      "github": "Github",
+      "reddit": "Reddit",
+      "mattermost": "Mattermost",
+      "twitter": "Twitter"
     }
   },
-  "faq": {
-    "a": {
-      "come-in": "Метою Rocky Linux є побудова безкоштовного дистрибутиву, випуски якого будуть виходити вслід за випусками комерційної системи, а не перед ними. Роль такого дистрибутиву раніше виконував CentOS.",
-      "downstream-partner-direction": "Проєкт CentOS нещодавно оголосив про зміну стратегії розвитку та підтримки операційної системи CentOS. Попередньо, CentOS існувала як безкоштовний дистрибутив комерційної та стабільної системи (CentOS отримувала правки та оновлення після того, як їх отримав комерційний дистрибутив). Надалі, CentOS стане гілкою розробки та тестування комерційного дистрибутиву, а отже тестові правки та оновлення будуть виходити для CentOS до того, як потраплять в комерційний дистрибутив. До того ж, період підтримки CentOS Linux 8 було скорочено, з 31-го травня, 2029-го року до 31-го грудня, 2021-го."
+
+  "homepage": {
+    "landing": {
+      "p1": {
+        "heading": "Rocky Linux",
+        "content": "Спільна ініціатива зі створення системи Linux коропортативного рівня."
+      },
+      "p2": {
+        "heading": "Що таке проєкт Rocky Linux?",
+        "content": "Rocky Linux це спільна операційна система корпоративного рівня, спроєктована, щоб забезпечити 100% сумісності з найпопулярнішою американською корпоративною Linux системою CentOS. Розробка Rocky Linux була спровокована кардинальною зміною у напрямку розвитку CentOS. Rocky Linux активно розвивається спільнотою. Проєктом керує Gregory Kurtzer, засновник CentOS. Наразі, планова дата першого випуску невідома. Бажаючі долучитись, будь ласка виходьте на зв'язок через один з каналів зазначених на цьому сайті."
+      }
     },
-    "q": {
-      "come-in": "Отже, яке місце Rocky Linux на ринку?",
-      "downstream-partner-direction": "Що означає, \"кардинальна зміна у напрямку розвитку CentOS?\""
-    },
-    "title": "Часті запитання."
+    "faq": {
+      "title": "Часті запитання.",
+      "a": {
+        "come-in": "Метою Rocky Linux є побудова безкоштовного дистрибутиву, випуски якого будуть виходити вслід за випусками комерційної системи, а не перед ними. Роль такого дистрибутиву раніше виконував CentOS.",
+        "downstream-partner-direction": "Проєкт CentOS нещодавно оголосив про зміну стратегії розвитку та підтримки операційної системи CentOS. Попередньо, CentOS існувала як безкоштовний дистрибутив комерційної та стабільної системи (CentOS отримувала правки та оновлення після того, як їх отримав комерційний дистрибутив). Надалі, CentOS стане гілкою розробки та тестування комерційного дистрибутиву, а отже тестові правки та оновлення будуть виходити для CentOS до того, як потраплять в комерційний дистрибутив. До того ж, період підтримки CentOS Linux 8 було скорочено, з 31-го травня, 2029-го року до 31-го грудня, 2021-го."
+      },
+      "q": {
+        "come-in": "Отже, яке місце Rocky Linux на ринку?",
+        "downstream-partner-direction": "Що означає, \"кардинальна зміна у напрямку розвитку CentOS?\""
+      }
+    }
   },
-  "landing": {
+
+  "download": {
     "p1": {
-      "content": "Спільна ініціатива зі створення системи Linux коропортативного рівня.",
-      "heading": "Rocky Linux"
+      "heading": "Downloads",
+      "content": "Download the official release of Rocky Linux from one of our trusted mirrors."
+    },
+    "warning": "The release you can download here is a <i>Release Candidate</i> and should not be used in production. Please check our <a class=\"underline font-medium\" href=\"/faq/\">FAQ</a> for more information.",
+    "table": {
+      "architecture": "Architecture",
+      "iso": "ISOS",
+      "isos": {
+        "minimal": "Minimal",
+        "dvd": "DVD",
+        "boot": "Boot",
+        "checksum": "Checksum"
+      },
+      "packages": "Packages"
     },
     "p2": {
-      "content": "Rocky Linux це спільна операційна система корпоративного рівня, спроєктована, щоб забезпечити 100% сумісності з найпопулярнішою американською корпоративною Linux системою CentOS. Розробка Rocky Linux була спровокована кардинальною зміною у напрямку розвитку CentOS. Rocky Linux активно розвивається спільнотою. Проєктом керує Gregory Kurtzer, засновник CentOS. Наразі, планова дата першого випуску невідома. Бажаючі долучитись, будь ласка виходьте на зв'язок через один з каналів зазначених на цьому сайті.",
-      "heading": "Що таке проєкт Rocky Linux?"
+      "content": "As you download and use Rocky Linux, the Rocky Enterprise Software Foundation invites you to <a class=\"text-green-600 dark:text-green-500 font-medium\" href=\"https://chat.rockylinux.org/\">be a part of the community as a contributor</a>. There are many ways to contribute to the project, from documentation, QA, and testing to coding changes for SIGs, providing mirroring or hosting, and helping other users."
     }
   },
+
   "lang": {
     "footer": {
       "choose-language": "Оберіть мову..."
     }
   },
-  "links": {
-    "close-menu": "Закрити меню",
-    "documentation": "Документація",
-    "get-in-touch": "Контакти",
-    "get-involved": "Долучитись",
-    "go-home": "Домашня сторінка",
-    "join-the-discussion": "Долучитись до дискусії",
-    "posts": "News",
-    "show-your-interest": "Show Your Interest",
-    "sponsors": "Sponsors",
-    "donate": "Donate",
-    "store": "Store",
-    "press": "Press"
+
+  "errors": {
+    "404": {
+      "title": "Сторінку не знайдено.",
+      "explanation": "Запитуваний ресурс не було знайдено. Будь ласка спробуйте ще раз."
+    }
   },
-  "socials": {
-    "forums": "Forums",
-    "github": "Github",
-    "reddit": "Reddit",
-    "mattermost": "Mattermost",
-    "twitter": "Twitter"
-  },
+
   "news": {
     "title": "News",
     "description": "Stay up-to-date on the latest from The Rocky Linux Project."
   },
+
   "press": {
     "title": "Press",
     "description": "See the latest about Rocky in the press."
   },
+
   "sponsors": {
     "title": "Sponsors",
-    "description": "We would like to thank our sponsors for their support thus far on the project."
+    "description": "We would like to thank our sponsors for their support thus far on the project.",
+    "tag": {
+      "fsponsor": "Founding Sponsor",
+      "psponsor": "Principal Sponsor"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "45drives": {
+        "name": "45Drives",
+        "description": "45Drives offers enterprise storage solutions built on powerful & robust open-source software that allows customers to benefit from the cost savings & flexibility of off-the-shelf hardware. Check them out for a fully supported data storage solution at the best cost per terabyte!"
+      },
+      "opendrives": {
+        "name": "OpenDrives",
+        "description": "OpenDrives is a global provider of enterprise-grade, hyper-scalable, network-attached-storage (NAS) solutions. We deliver the highest performing solutions for our customers - to match individual performance needs - for the most robust, complex and mission-critical projects and workflows, on-premises and into the cloud."
+      },
+      "montavista": {
+        "name": "MontaVista",
+        "description": "MontaVista Software is the leader in embedded commercial Linux, supporting MontaVista CGX, Yocto Project®, CentOS and Rocky Linux. MontaVista offers Open Source Software expertise, commercial-quality Linux distros, cost-effective maintenance and support for 10+ year life-cycles."
+      },
+      "aws": {
+        "name": "Amazon Web Services",
+        "description": "The RESF utilizes AWS to run much of the underlying infrastructure critical to the development and deployment of the services supporting Rocky Linux. From Koji builders for x86_64 and aarch64 running in EC2 to SRPM blob storage in S3, AWS is foundational to much of what we do."
+      }
+    }
+  },
+
+  "partners": {
+    "title": "Partners",
+    "description": "Partners of the RESF represent ongoing relationships of strategic importance to the Rocky Linux project. Through dedication of engineering expertise, infrastructure resources, or other means, their support is critical to our continued success and long term stability.",
+    "tag": {
+      "fpartner": "Founding Partner",
+      "ppartner": "Principal Partner"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "navercloud": {
+        "name": "NAVER Cloud",
+        "description": "NAVER Cloud Platform is a South Korean cloud service that started in 2017 under NAVER Cloud, a subsidiary of NAVER. It provides over 170 individual services in 2021 and holds various security certifications including CSA STAR GOLD, GDPR, and more. It also currently provides cloud services in 10 locations around the world."
+      },
+      "mattermost": {
+        "name": "Mattermost",
+        "description": "Mattermost is an open source messaging solution made for organizations with the highest security requirements. As big believers in the power of open source, Mattermost is thrilled to partner with RESF to help bring an enterprise-grade distribution of Linux to the tech community."
+      }
+    }
+  },
+
+  "faq": {
+    "heading": "Frequently Asked Questions",
+    "q1": {
+      "q": "Where can I download the release candidate?",
+      "a": "https://rockylinux.org/download"
+    },
+    "q2": {
+      "q": "What is a release candidate?",
+      "a": "A release candidate is a beta version of a product that has the potential to be stable.The intent of a release candidate is for the community to test and validate expected functionality of Rocky Linux and report any bugs if present."
+    },
+    "q3": {
+      "q": "Can I use the release candidate in production?",
+      "a": "Under no circumstance should you use a release candidate in a production environment. A release candidate is provided for testing and validation purposes only."
+    },
+    "q4": {
+      "q": "How can I help mirror the release candidate and future Rocky Linux releases?",
+      "a": "Please email <a href=\"mailto:mirrors@rockylinux.org\">mirrors@rockylinux.org</a> to express your interest."
+    },
+    "q5": {
+      "q": "I encountered a bug while testing the release candidate, what can I do?",
+      "a": "First, create an account using <a href=\"https://accounts.rockylinux.org/\"> Rocky Linux Account Services </a> , then head over to our <a href=\"https://bugs.rockylinux.org/\">Bugzilla server</a> to report any bugs."
+    },
+    "q6": {
+      "q": "How can I get involved with the Testing team?",
+      "a": "Please join the <a href=\"https://chat.rockylinux.org/rocky-linux/channels/testing\"> ~Testing </a> channel on our Mattermost server to get started. There’s also a testing topic on the forums for more durable conversation."
+    },
+    "q7": {
+      "q": "Where can I find the latest news about Rocky Linux?",
+      "a": "Stay tuned to our website, Twitter, LinkedIn, forums, and other platforms listed in our link directory for the latest announcements."
+    },
+    "q8": {
+      "q": "If Rocky Linux is just a respin of RHEL, what took so long for a release candidate?",
+      "a1": "If our only goal for Rocky Linux was to debrand and repackage RHEL, we would have been done much sooner. However, what we had to do differently is figure out how we could keep Rocky Linux in the hands of the community. Carefully devising this strategy ensures that Rocky Linux will never meet the same fate of CentOS.",
+      "a2": "The goal was not just to create a community managed RPM based distribution of Linux, but to ensure that it will remain freely available and always in the control of the community, much like Linux itself has. To do that required more than a build infrastructure; it required that we put in place the foundational structures that enable the community, ensuring that Rocky Linux is forever inclusive, free, and open. The infrastructure is built from the ground up by many collaborators and sponsoring organizations around composability and security compliance, providing the substrate for not only the base operating system but also an entire community of diverse interests to take part in the project."
+    },
+    "q9": {
+      "q": "If you’re not just repackaging RHEL, then what exactly are you doing?",
+      "a": "Our goal is to maintain Rocky Linux as a community-oriented distribution <i>by</i> the community, <i>for</i> the community. To do this, we are establishing the necessary organizational structures to ensure that Rocky Linux remains in the hands of the community. We want to make sure that it’s not possible for what happened to CentOS to happen to Rocky Linux."
+    },
+    "q10": {
+      "q": "How will you ensure that Rocky Linux truly remains a community enterprise operating system?",
+      "a": "First, we’ve taken steps to legally protect the Rocky Linux name. This means registering its trademarks and various associated properties to protect them from being controlled by another entity. We’ve achieved this by establishing them under the Rocky Enterprise Software Foundation (RESF). Next, we’re drafting a community charter that will define the organizational structure, objectives, values, and mission behind the legal entity that represents Rocky Linux. Critical in this charter is the establishment of principles that enable and protect the community: transparency, community involvement, open development, and independence. <strong> Rocky Linux will never be controlled, purchased, or otherwise influenced by a single entity or organization. </strong> Finally, we’re architecting and deploying the necessary infrastructure to further enable the community to contribute to Rocky Linux."
+    },
+    "q11": {
+      "q": "What infrastructure is necessary to enable the community?",
+      "a1": "We’ve established a number of teams to support the various efforts associated with developing Rocky Linux:",
+      "a2": "You can read more about this structure when it’s soon published. In order to enable collaboration across and within those teams, we needed to deploy our own chat infrastructure, forums, and website. Additionally, we’re also creating our build infrastructure, which will facilitate the development of the core operating system.",
+      "list": {
+        "community": "Community",
+        "core-inf": "Core Infrastructure",
+        "design": "Design",
+        "documentation": "Documentation",
+        "installer": "Installer",
+        "leadership": "Leadership",
+        "pkg-autob": "Package Auto-Builders",
+        "packaging": "Packaging",
+        "security": "Security",
+        "sigs": "Special Interest Groups (SIGs)",
+        "web": "Web"
+      }
+    },
+    "q12": {
+      "q": "Why does it take so much time to stand up a community and build infrastructure?",
+      "a": "It’s not terribly difficult to deploy a website, forums, or a build infrastructure in a reliable fashion. Our chat program for instance, which uses Mattermost, is distributed on a number of application servers behind a load balancer and was ready in just a couple of weeks. But it does require careful thought and planning to do it in a scalable and secure manner when you need to ensure vendor and platform agnosticity and long-term community involvement."
+    },
+    "q13": {
+      "q": "So what’s the short answer to all of this? What are some things you’re thinking about as you put Rocky Linux together?",
+      "a": "How do we carefully shepherd community trust? How do we ensure that anyone who wants to participate can not only do so immediately, but forever in the future as well? How do we engage and enable the community members who might not be as technical but want to contribute anyway? Solving for all of these challenges will take time, and we would love your help in doing so."
+    },
+    "q14": {
+      "q": "What if I have feedback or my question wasn’t answered here?",
+      "a": "Please email us: <a href=\"mailto:hello@rockylinux.org\">hello@rockylinux.org</a> and we’ll get back to you as soon as we can."
+    }
   }
 }

--- a/src/i18n/locales/vi/translation.json
+++ b/src/i18n/locales/vi/translation.json
@@ -1,72 +1,241 @@
 {
   "language": "vi",
-  "copyright": {
-    "line1": "© 2021 The Rocky Linux Project. Đã đăng ký bản quyền.",
-    "line2": "CentOS là nhẵn hiệu được đăng ký bởi Red Hat, Inc. Dự án The Rocky Linux không liên kết cũng như xác nhận bởi Red Hat, Inc."
-  },
-  "errors": {
-    "404": {
-      "explanation": "Yêu cầu khồng được tìm thấy. Vui lòng thử lại.",
-      "title": "Trang không tìm thấy."
+
+  "global": {
+
+    "copyright": {
+      "line1": "© 2021 The Rocky Linux Project. Đã đăng ký bản quyền.",
+      "line2": "CentOS là nhẵn hiệu được đăng ký bởi Red Hat, Inc. Dự án The Rocky Linux không liên kết cũng như xác nhận bởi Red Hat, Inc."
+    },
+
+    "links": {
+      "close-menu": "Đóng menu",
+      "wiki": "Wiki",
+      "get-in-touch": "Giữ liên lạc",
+      "get-involved": "Tham gia",
+      "go-home": "Trang chủ",
+      "join-the-discussion": "Tham gia thảo luận",
+      "posts": "News",
+      "show-your-interest": "Show Your Interest",
+      "sponsors": "Sponsors",
+      "partners": "Partners",
+      "status": "Service Status",
+      "donate": "Donate",
+      "store": "Store",
+      "press": "Press",
+      "download": "Download",
+      "com_charter": "Community Charter",
+      "org_structure": "Organization Structure",
+      "privacy": "Privacy Policy",
+      "see-more": "See More",
+      "see-all": "See All",
+      "documentation": "Tài liệu",
+      "bug-report": "Report a bug"
+    },
+    "socials": {
+      "forums": "Diễn đàn",
+      "github": "Github",
+      "reddit": "Reddit",
+      "mattermost": "Mattermost",
+      "twitter": "Twitter"
     }
   },
-  "faq": {
-    "a": {
-      "come-in": "Rocky Linux nhằm mục đích hoạt động như một bản downstream build như CentOS đã làm trước đây, xây dựng các bản phát hành sau khi chúng được  upstream vendor thêm vào, chứ không phải trước đó.",
-      "downstream-partner-direction": "Dự án CentOS gần đây đã thông báo về sự thay đổi chiến lược cho CentOS. Trong khi trước đây CentOS tồn tại như một bản downstream build của upstream vendor (nó nhận được các bản vá và cập nhật sau khi upstream vendor thực hiện), nó sẽ chuyển sang bản upstream build (thử nghiệm các bản vá và cập nhật trước khi đưa vào upstream vendor). Ngoài ra, hỗ trợ cho CentOS Linux 8 đã bị cắt ngắn, từ ngày 31 tháng 5 năm 2029 đến ngày 31 tháng 12 năm 2021."
+
+  "homepage": {
+    "landing": {
+      "p1": {
+        "heading": "Rocky Linux",
+        "content": "Một nỗ lực vì cộng đổng nhằm mang tới cho bạn Linux phiên bản doạnh nghiệp, sản phẩm hoàn thiện."
+      },
+      "p2": {
+        "heading": "Dự án Rocky Linux là gì?",
+        "content": "Rocky Linux là một hệ điều hành cộng đồng dành cho doanh nghiệp được thiết kế để tương thích 100% với lỗi tương thích với bản phân phối Linux dành cho doanh nghiệp hàng đầu của Mỹ hiện nay khi downstream partner của nó đã chuyển hướng. Nó đang được cộng đồng phát triển mạnh thêm. Rocky Linux được dẫn dắt bởi Gregory Kurtzer, người sáng lập dự án CentOS. Không có ETA cho một bản phát hành. Các cộng tác viên được yêu cầu liên hệ bằng cách sử dụng các tùy chọn liên lạc được cung cấp trên trang web này."
+      }
     },
-    "q": {
-      "come-in": "Vậy Rocky Linux tới từ đâu?",
-      "downstream-partner-direction": "Câu này nghĩa là gì, \"Downstream partner của nó đã chuyển hướng?\""
-    },
-    "title": "Câu hỏi thường gặp"
+    "faq": {
+      "title": "Câu hỏi thường gặp",
+      "a": {
+        "come-in": "Rocky Linux nhằm mục đích hoạt động như một bản downstream build như CentOS đã làm trước đây, xây dựng các bản phát hành sau khi chúng được  upstream vendor thêm vào, chứ không phải trước đó.",
+        "downstream-partner-direction": "Dự án CentOS gần đây đã thông báo về sự thay đổi chiến lược cho CentOS. Trong khi trước đây CentOS tồn tại như một bản downstream build của upstream vendor (nó nhận được các bản vá và cập nhật sau khi upstream vendor thực hiện), nó sẽ chuyển sang bản upstream build (thử nghiệm các bản vá và cập nhật trước khi đưa vào upstream vendor). Ngoài ra, hỗ trợ cho CentOS Linux 8 đã bị cắt ngắn, từ ngày 31 tháng 5 năm 2029 đến ngày 31 tháng 12 năm 2021."
+      },
+      "q": {
+        "come-in": "Vậy Rocky Linux tới từ đâu?",
+        "downstream-partner-direction": "Câu này nghĩa là gì, \"Downstream partner của nó đã chuyển hướng?\""
+      }
+    }
   },
-  "landing": {
+
+  "download": {
     "p1": {
-      "content": "Một nỗ lực vì cộng đổng nhằm mang tới cho bạn Linux phiên bản doạnh nghiệp, sản phẩm hoàn thiện.",
-      "heading": "Rocky Linux"
+      "heading": "Downloads",
+      "content": "Download the official release of Rocky Linux from one of our trusted mirrors."
+    },
+    "warning": "The release you can download here is a <i>Release Candidate</i> and should not be used in production. Please check our <a class=\"underline font-medium\" href=\"/faq/\">FAQ</a> for more information.",
+    "table": {
+      "architecture": "Architecture",
+      "iso": "ISOS",
+      "isos": {
+        "minimal": "Minimal",
+        "dvd": "DVD",
+        "boot": "Boot",
+        "checksum": "Checksum"
+      },
+      "packages": "Packages"
     },
     "p2": {
-      "content": "Rocky Linux là một hệ điều hành cộng đồng dành cho doanh nghiệp được thiết kế để tương thích 100% với lỗi tương thích với bản phân phối Linux dành cho doanh nghiệp hàng đầu của Mỹ hiện nay khi downstream partner của nó đã chuyển hướng. Nó đang được cộng đồng phát triển mạnh thêm. Rocky Linux được dẫn dắt bởi Gregory Kurtzer, người sáng lập dự án CentOS. Không có ETA cho một bản phát hành. Các cộng tác viên được yêu cầu liên hệ bằng cách sử dụng các tùy chọn liên lạc được cung cấp trên trang web này.",
-      "heading": "Dự án Rocky Linux là gì?"
+      "content": "As you download and use Rocky Linux, the Rocky Enterprise Software Foundation invites you to <a class=\"text-green-600 dark:text-green-500 font-medium\" href=\"https://chat.rockylinux.org/\">be a part of the community as a contributor</a>. There are many ways to contribute to the project, from documentation, QA, and testing to coding changes for SIGs, providing mirroring or hosting, and helping other users."
     }
   },
+
   "lang": {
     "footer": {
       "choose-language": "Chọn một ngôn ngữ..."
     }
   },
-  "links": {
-    "close-menu": "Đóng menu",
-    "documentation": "Tài liệu",
-    "get-in-touch": "Giữ liên lạc",
-    "get-involved": "Tham gia",
-    "go-home": "Trang chủ",
-    "join-the-discussion": "Tham gia thảo luận",
-    "posts": "News",
-    "show-your-interest": "Show Your Interest",
-    "sponsors": "Sponsors",
-    "donate": "Donate",
-    "store": "Store",
-    "press": "Press"
+
+  "errors": {
+    "404": {
+      "title": "Trang không tìm thấy.",
+      "explanation": "Yêu cầu khồng được tìm thấy. Vui lòng thử lại."
+    }
   },
-  "socials": {
-    "forums": "Diễn đàn",
-    "github": "Github",
-    "reddit": "Reddit",
-    "mattermost": "Mattermost",
-    "twitter": "Twitter"
-  },
+
   "news": {
     "title": "News",
     "description": "Stay up-to-date on the latest from The Rocky Linux Project."
   },
+
   "press": {
     "title": "Press",
     "description": "See the latest about Rocky in the press."
   },
+
   "sponsors": {
     "title": "Sponsors",
-    "description": "We would like to thank our sponsors for their support thus far on the project."
+    "description": "We would like to thank our sponsors for their support thus far on the project.",
+    "tag": {
+      "fsponsor": "Founding Sponsor",
+      "psponsor": "Principal Sponsor"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "45drives": {
+        "name": "45Drives",
+        "description": "45Drives offers enterprise storage solutions built on powerful & robust open-source software that allows customers to benefit from the cost savings & flexibility of off-the-shelf hardware. Check them out for a fully supported data storage solution at the best cost per terabyte!"
+      },
+      "opendrives": {
+        "name": "OpenDrives",
+        "description": "OpenDrives is a global provider of enterprise-grade, hyper-scalable, network-attached-storage (NAS) solutions. We deliver the highest performing solutions for our customers - to match individual performance needs - for the most robust, complex and mission-critical projects and workflows, on-premises and into the cloud."
+      },
+      "montavista": {
+        "name": "MontaVista",
+        "description": "MontaVista Software is the leader in embedded commercial Linux, supporting MontaVista CGX, Yocto Project®, CentOS and Rocky Linux. MontaVista offers Open Source Software expertise, commercial-quality Linux distros, cost-effective maintenance and support for 10+ year life-cycles."
+      },
+      "aws": {
+        "name": "Amazon Web Services",
+        "description": "The RESF utilizes AWS to run much of the underlying infrastructure critical to the development and deployment of the services supporting Rocky Linux. From Koji builders for x86_64 and aarch64 running in EC2 to SRPM blob storage in S3, AWS is foundational to much of what we do."
+      }
+    }
+  },
+
+  "partners": {
+    "title": "Partners",
+    "description": "Partners of the RESF represent ongoing relationships of strategic importance to the Rocky Linux project. Through dedication of engineering expertise, infrastructure resources, or other means, their support is critical to our continued success and long term stability.",
+    "tag": {
+      "fpartner": "Founding Partner",
+      "ppartner": "Principal Partner"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "navercloud": {
+        "name": "NAVER Cloud",
+        "description": "NAVER Cloud Platform is a South Korean cloud service that started in 2017 under NAVER Cloud, a subsidiary of NAVER. It provides over 170 individual services in 2021 and holds various security certifications including CSA STAR GOLD, GDPR, and more. It also currently provides cloud services in 10 locations around the world."
+      },
+      "mattermost": {
+        "name": "Mattermost",
+        "description": "Mattermost is an open source messaging solution made for organizations with the highest security requirements. As big believers in the power of open source, Mattermost is thrilled to partner with RESF to help bring an enterprise-grade distribution of Linux to the tech community."
+      }
+    }
+  },
+
+  "faq": {
+    "heading": "Frequently Asked Questions",
+    "q1": {
+      "q": "Where can I download the release candidate?",
+      "a": "https://rockylinux.org/download"
+    },
+    "q2": {
+      "q": "What is a release candidate?",
+      "a": "A release candidate is a beta version of a product that has the potential to be stable.The intent of a release candidate is for the community to test and validate expected functionality of Rocky Linux and report any bugs if present."
+    },
+    "q3": {
+      "q": "Can I use the release candidate in production?",
+      "a": "Under no circumstance should you use a release candidate in a production environment. A release candidate is provided for testing and validation purposes only."
+    },
+    "q4": {
+      "q": "How can I help mirror the release candidate and future Rocky Linux releases?",
+      "a": "Please email <a href=\"mailto:mirrors@rockylinux.org\">mirrors@rockylinux.org</a> to express your interest."
+    },
+    "q5": {
+      "q": "I encountered a bug while testing the release candidate, what can I do?",
+      "a": "First, create an account using <a href=\"https://accounts.rockylinux.org/\"> Rocky Linux Account Services </a> , then head over to our <a href=\"https://bugs.rockylinux.org/\">Bugzilla server</a> to report any bugs."
+    },
+    "q6": {
+      "q": "How can I get involved with the Testing team?",
+      "a": "Please join the <a href=\"https://chat.rockylinux.org/rocky-linux/channels/testing\"> ~Testing </a> channel on our Mattermost server to get started. There’s also a testing topic on the forums for more durable conversation."
+    },
+    "q7": {
+      "q": "Where can I find the latest news about Rocky Linux?",
+      "a": "Stay tuned to our website, Twitter, LinkedIn, forums, and other platforms listed in our link directory for the latest announcements."
+    },
+    "q8": {
+      "q": "If Rocky Linux is just a respin of RHEL, what took so long for a release candidate?",
+      "a1": "If our only goal for Rocky Linux was to debrand and repackage RHEL, we would have been done much sooner. However, what we had to do differently is figure out how we could keep Rocky Linux in the hands of the community. Carefully devising this strategy ensures that Rocky Linux will never meet the same fate of CentOS.",
+      "a2": "The goal was not just to create a community managed RPM based distribution of Linux, but to ensure that it will remain freely available and always in the control of the community, much like Linux itself has. To do that required more than a build infrastructure; it required that we put in place the foundational structures that enable the community, ensuring that Rocky Linux is forever inclusive, free, and open. The infrastructure is built from the ground up by many collaborators and sponsoring organizations around composability and security compliance, providing the substrate for not only the base operating system but also an entire community of diverse interests to take part in the project."
+    },
+    "q9": {
+      "q": "If you’re not just repackaging RHEL, then what exactly are you doing?",
+      "a": "Our goal is to maintain Rocky Linux as a community-oriented distribution <i>by</i> the community, <i>for</i> the community. To do this, we are establishing the necessary organizational structures to ensure that Rocky Linux remains in the hands of the community. We want to make sure that it’s not possible for what happened to CentOS to happen to Rocky Linux."
+    },
+    "q10": {
+      "q": "How will you ensure that Rocky Linux truly remains a community enterprise operating system?",
+      "a": "First, we’ve taken steps to legally protect the Rocky Linux name. This means registering its trademarks and various associated properties to protect them from being controlled by another entity. We’ve achieved this by establishing them under the Rocky Enterprise Software Foundation (RESF). Next, we’re drafting a community charter that will define the organizational structure, objectives, values, and mission behind the legal entity that represents Rocky Linux. Critical in this charter is the establishment of principles that enable and protect the community: transparency, community involvement, open development, and independence. <strong> Rocky Linux will never be controlled, purchased, or otherwise influenced by a single entity or organization. </strong> Finally, we’re architecting and deploying the necessary infrastructure to further enable the community to contribute to Rocky Linux."
+    },
+    "q11": {
+      "q": "What infrastructure is necessary to enable the community?",
+      "a1": "We’ve established a number of teams to support the various efforts associated with developing Rocky Linux:",
+      "a2": "You can read more about this structure when it’s soon published. In order to enable collaboration across and within those teams, we needed to deploy our own chat infrastructure, forums, and website. Additionally, we’re also creating our build infrastructure, which will facilitate the development of the core operating system.",
+      "list": {
+        "community": "Community",
+        "core-inf": "Core Infrastructure",
+        "design": "Design",
+        "documentation": "Documentation",
+        "installer": "Installer",
+        "leadership": "Leadership",
+        "pkg-autob": "Package Auto-Builders",
+        "packaging": "Packaging",
+        "security": "Security",
+        "sigs": "Special Interest Groups (SIGs)",
+        "web": "Web"
+      }
+    },
+    "q12": {
+      "q": "Why does it take so much time to stand up a community and build infrastructure?",
+      "a": "It’s not terribly difficult to deploy a website, forums, or a build infrastructure in a reliable fashion. Our chat program for instance, which uses Mattermost, is distributed on a number of application servers behind a load balancer and was ready in just a couple of weeks. But it does require careful thought and planning to do it in a scalable and secure manner when you need to ensure vendor and platform agnosticity and long-term community involvement."
+    },
+    "q13": {
+      "q": "So what’s the short answer to all of this? What are some things you’re thinking about as you put Rocky Linux together?",
+      "a": "How do we carefully shepherd community trust? How do we ensure that anyone who wants to participate can not only do so immediately, but forever in the future as well? How do we engage and enable the community members who might not be as technical but want to contribute anyway? Solving for all of these challenges will take time, and we would love your help in doing so."
+    },
+    "q14": {
+      "q": "What if I have feedback or my question wasn’t answered here?",
+      "a": "Please email us: <a href=\"mailto:hello@rockylinux.org\">hello@rockylinux.org</a> and we’ll get back to you as soon as we can."
+    }
   }
 }

--- a/src/i18n/locales/zh-cn/translation.json
+++ b/src/i18n/locales/zh-cn/translation.json
@@ -1,73 +1,241 @@
 {
   "language": "zh-cn",
-  "copyright": {
-    "line1": "© 2021 Rocky Linux 项目。版权所有。",
-    "line2": "CentOS 是红帽公司（Red Hat, Inc.）的注册商标，Rocky Linux 项目既不隶属于红帽公司（Red Hat, Inc.），也无受其认可。"
-  },
-  "errors": {
-    "404": {
-      "explanation": "找不到您请求的资源，请稍后再试。",
-      "title": "找不到页面。"
+
+  "global": {
+
+    "copyright": {
+      "line1": "© 2021 Rocky Linux 项目。版权所有。",
+      "line2": "CentOS 是红帽公司（Red Hat, Inc.）的注册商标，Rocky Linux 项目既不隶属于红帽公司（Red Hat, Inc.），也无受其认可。"
+    },
+
+    "links": {
+      "close-menu": "关闭菜单",
+      "wiki": "Wiki",
+      "get-in-touch": "联系我们",
+      "get-involved": "参与我们",
+      "go-home": "前往主页",
+      "join-the-discussion": "加入讨论",
+      "posts": "News",
+      "show-your-interest": "Show Your Interest",
+      "sponsors": "Sponsors",
+      "partners": "Partners",
+      "status": "Service Status",
+      "donate": "Donate",
+      "store": "Store",
+      "press": "Press",
+      "download": "Download",
+      "com_charter": "Community Charter",
+      "org_structure": "Organization Structure",
+      "privacy": "Privacy Policy",
+      "see-more": "See More",
+      "see-all": "See All",
+      "documentation": "文档",
+      "bug-report": "Report a bug"
+    },
+    "socials": {
+      "forums": "论坛",
+      "github": "Github",
+      "reddit": "Reddit",
+      "mattermost": "Mattermost",
+      "twitter": "Twitter"
     }
   },
-  "faq": {
-    "a": {
-      "come-in": "Rocky Linux 的目标是像 CentOS 以前那样作为一个下游构建版本，在被上游供应商纳入包更新之后（而不是之前）构建发行。",
-      "downstream-partner-direction": "CentOS 项目最近宣布了 CentOS 的战略转变，CentOS 以前是作为上游供应商的下游构建版本存在的（即它会在上游供应商之后收到补丁和更新），而现在它将转移为一个上游构建版本（即它会在上游供应商纳入之前测试补丁和更新）。另外，对 CentOS Linux 8 的支持也已从 2029年 5 月 31 日缩短至 2021 年 12 月 31 日。"
+
+  "homepage": {
+    "landing": {
+      "p1": {
+        "heading": "Rocky Linux",
+        "content": "以社区驱动为导向，为您带来企业级、可生产的 Linux 系统。"
+      },
+      "p2": {
+        "heading": "Rocky Linux 项目是什么?",
+        "content": "Rocky Linux 是一个社区化的企业级操作系统。其设计为的是与美国顶级企业 Linux 发行版实现 100％ Bug 级兼容，而原因是后者的下游合作伙伴转移了发展方向。目前社区正在集中力量发展有关设施。Rocky Linux 由 CentOS 项目的创始人 Gregory Kurtzer 领导。目前没有发布的具体时间。贡献者们须要用本网站上提供的通讯方式与我们联系。"
+      }
     },
-    "q": {
-      "come-in": "那么 Rocky Linux 从何而来呢？",
-      "downstream-partner-direction": "“下游合作伙伴转移了发展方向”是什么意思？"
-    },
-    "title": "常见问题"
+    "faq": {
+      "title": "常见问题",
+      "a": {
+        "come-in": "Rocky Linux 的目标是像 CentOS 以前那样作为一个下游构建版本，在被上游供应商纳入包更新之后（而不是之前）构建发行。",
+        "downstream-partner-direction": "CentOS 项目最近宣布了 CentOS 的战略转变，CentOS 以前是作为上游供应商的下游构建版本存在的（即它会在上游供应商之后收到补丁和更新），而现在它将转移为一个上游构建版本（即它会在上游供应商纳入之前测试补丁和更新）。另外，对 CentOS Linux 8 的支持也已从 2029年 5 月 31 日缩短至 2021 年 12 月 31 日。"
+      },
+      "q": {
+        "come-in": "那么 Rocky Linux 从何而来呢？",
+        "downstream-partner-direction": "“下游合作伙伴转移了发展方向”是什么意思？"
+      }
+    }
   },
-  "landing": {
+
+  "download": {
     "p1": {
-      "content": "以社区驱动为导向，为您带来企业级、可生产的 Linux 系统。",
-      "heading": "Rocky Linux"
+      "heading": "Downloads",
+      "content": "Download the official release of Rocky Linux from one of our trusted mirrors."
+    },
+    "warning": "The release you can download here is a <i>Release Candidate</i> and should not be used in production. Please check our <a class=\"underline font-medium\" href=\"/faq/\">FAQ</a> for more information.",
+    "table": {
+      "architecture": "Architecture",
+      "iso": "ISOS",
+      "isos": {
+        "minimal": "Minimal",
+        "dvd": "DVD",
+        "boot": "Boot",
+        "checksum": "Checksum"
+      },
+      "packages": "Packages"
     },
     "p2": {
-      "content": "Rocky Linux 是一个社区化的企业级操作系统。其设计为的是与美国顶级企业 Linux 发行版实现 100％ Bug 级兼容，而原因是后者的下游合作伙伴转移了发展方向。目前社区正在集中力量发展有关设施。Rocky Linux 由 CentOS 项目的创始人 Gregory Kurtzer 领导。目前没有发布的具体时间。贡献者们须要用本网站上提供的通讯方式与我们联系。",
-      "heading": "Rocky Linux 项目是什么?"
+      "content": "As you download and use Rocky Linux, the Rocky Enterprise Software Foundation invites you to <a class=\"text-green-600 dark:text-green-500 font-medium\" href=\"https://chat.rockylinux.org/\">be a part of the community as a contributor</a>. There are many ways to contribute to the project, from documentation, QA, and testing to coding changes for SIGs, providing mirroring or hosting, and helping other users."
     }
   },
+
   "lang": {
     "footer": {
-      "choose-language": "选择一种语言...",
-      "literal": "Language:"
+      "choose-language": "选择一种语言..."
     }
   },
-  "links": {
-    "close-menu": "关闭菜单",
-    "documentation": "文档",
-    "get-in-touch": "联系我们",
-    "get-involved": "参与我们",
-    "go-home": "前往主页",
-    "join-the-discussion": "加入讨论",
-    "posts": "News",
-    "show-your-interest": "Show Your Interest",
-    "sponsors": "Sponsors",
-    "donate": "Donate",
-    "store": "Store",
-    "press": "Press"
+
+  "errors": {
+    "404": {
+      "title": "找不到页面。",
+      "explanation": "找不到您请求的资源，请稍后再试。"
+    }
   },
-  "socials": {
-    "forums": "论坛",
-    "github": "Github",
-    "reddit": "Reddit",
-    "mattermost": "Mattermost",
-    "twitter": "Twitter"
-  },
+
   "news": {
     "title": "News",
     "description": "Stay up-to-date on the latest from The Rocky Linux Project."
   },
+
   "press": {
     "title": "Press",
     "description": "See the latest about Rocky in the press."
   },
+
   "sponsors": {
     "title": "Sponsors",
-    "description": "We would like to thank our sponsors for their support thus far on the project."
+    "description": "We would like to thank our sponsors for their support thus far on the project.",
+    "tag": {
+      "fsponsor": "Founding Sponsor",
+      "psponsor": "Principal Sponsor"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "45drives": {
+        "name": "45Drives",
+        "description": "45Drives offers enterprise storage solutions built on powerful & robust open-source software that allows customers to benefit from the cost savings & flexibility of off-the-shelf hardware. Check them out for a fully supported data storage solution at the best cost per terabyte!"
+      },
+      "opendrives": {
+        "name": "OpenDrives",
+        "description": "OpenDrives is a global provider of enterprise-grade, hyper-scalable, network-attached-storage (NAS) solutions. We deliver the highest performing solutions for our customers - to match individual performance needs - for the most robust, complex and mission-critical projects and workflows, on-premises and into the cloud."
+      },
+      "montavista": {
+        "name": "MontaVista",
+        "description": "MontaVista Software is the leader in embedded commercial Linux, supporting MontaVista CGX, Yocto Project®, CentOS and Rocky Linux. MontaVista offers Open Source Software expertise, commercial-quality Linux distros, cost-effective maintenance and support for 10+ year life-cycles."
+      },
+      "aws": {
+        "name": "Amazon Web Services",
+        "description": "The RESF utilizes AWS to run much of the underlying infrastructure critical to the development and deployment of the services supporting Rocky Linux. From Koji builders for x86_64 and aarch64 running in EC2 to SRPM blob storage in S3, AWS is foundational to much of what we do."
+      }
+    }
+  },
+
+  "partners": {
+    "title": "Partners",
+    "description": "Partners of the RESF represent ongoing relationships of strategic importance to the Rocky Linux project. Through dedication of engineering expertise, infrastructure resources, or other means, their support is critical to our continued success and long term stability.",
+    "tag": {
+      "fpartner": "Founding Partner",
+      "ppartner": "Principal Partner"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "navercloud": {
+        "name": "NAVER Cloud",
+        "description": "NAVER Cloud Platform is a South Korean cloud service that started in 2017 under NAVER Cloud, a subsidiary of NAVER. It provides over 170 individual services in 2021 and holds various security certifications including CSA STAR GOLD, GDPR, and more. It also currently provides cloud services in 10 locations around the world."
+      },
+      "mattermost": {
+        "name": "Mattermost",
+        "description": "Mattermost is an open source messaging solution made for organizations with the highest security requirements. As big believers in the power of open source, Mattermost is thrilled to partner with RESF to help bring an enterprise-grade distribution of Linux to the tech community."
+      }
+    }
+  },
+
+  "faq": {
+    "heading": "Frequently Asked Questions",
+    "q1": {
+      "q": "Where can I download the release candidate?",
+      "a": "https://rockylinux.org/download"
+    },
+    "q2": {
+      "q": "What is a release candidate?",
+      "a": "A release candidate is a beta version of a product that has the potential to be stable.The intent of a release candidate is for the community to test and validate expected functionality of Rocky Linux and report any bugs if present."
+    },
+    "q3": {
+      "q": "Can I use the release candidate in production?",
+      "a": "Under no circumstance should you use a release candidate in a production environment. A release candidate is provided for testing and validation purposes only."
+    },
+    "q4": {
+      "q": "How can I help mirror the release candidate and future Rocky Linux releases?",
+      "a": "Please email <a href=\"mailto:mirrors@rockylinux.org\">mirrors@rockylinux.org</a> to express your interest."
+    },
+    "q5": {
+      "q": "I encountered a bug while testing the release candidate, what can I do?",
+      "a": "First, create an account using <a href=\"https://accounts.rockylinux.org/\"> Rocky Linux Account Services </a> , then head over to our <a href=\"https://bugs.rockylinux.org/\">Bugzilla server</a> to report any bugs."
+    },
+    "q6": {
+      "q": "How can I get involved with the Testing team?",
+      "a": "Please join the <a href=\"https://chat.rockylinux.org/rocky-linux/channels/testing\"> ~Testing </a> channel on our Mattermost server to get started. There’s also a testing topic on the forums for more durable conversation."
+    },
+    "q7": {
+      "q": "Where can I find the latest news about Rocky Linux?",
+      "a": "Stay tuned to our website, Twitter, LinkedIn, forums, and other platforms listed in our link directory for the latest announcements."
+    },
+    "q8": {
+      "q": "If Rocky Linux is just a respin of RHEL, what took so long for a release candidate?",
+      "a1": "If our only goal for Rocky Linux was to debrand and repackage RHEL, we would have been done much sooner. However, what we had to do differently is figure out how we could keep Rocky Linux in the hands of the community. Carefully devising this strategy ensures that Rocky Linux will never meet the same fate of CentOS.",
+      "a2": "The goal was not just to create a community managed RPM based distribution of Linux, but to ensure that it will remain freely available and always in the control of the community, much like Linux itself has. To do that required more than a build infrastructure; it required that we put in place the foundational structures that enable the community, ensuring that Rocky Linux is forever inclusive, free, and open. The infrastructure is built from the ground up by many collaborators and sponsoring organizations around composability and security compliance, providing the substrate for not only the base operating system but also an entire community of diverse interests to take part in the project."
+    },
+    "q9": {
+      "q": "If you’re not just repackaging RHEL, then what exactly are you doing?",
+      "a": "Our goal is to maintain Rocky Linux as a community-oriented distribution <i>by</i> the community, <i>for</i> the community. To do this, we are establishing the necessary organizational structures to ensure that Rocky Linux remains in the hands of the community. We want to make sure that it’s not possible for what happened to CentOS to happen to Rocky Linux."
+    },
+    "q10": {
+      "q": "How will you ensure that Rocky Linux truly remains a community enterprise operating system?",
+      "a": "First, we’ve taken steps to legally protect the Rocky Linux name. This means registering its trademarks and various associated properties to protect them from being controlled by another entity. We’ve achieved this by establishing them under the Rocky Enterprise Software Foundation (RESF). Next, we’re drafting a community charter that will define the organizational structure, objectives, values, and mission behind the legal entity that represents Rocky Linux. Critical in this charter is the establishment of principles that enable and protect the community: transparency, community involvement, open development, and independence. <strong> Rocky Linux will never be controlled, purchased, or otherwise influenced by a single entity or organization. </strong> Finally, we’re architecting and deploying the necessary infrastructure to further enable the community to contribute to Rocky Linux."
+    },
+    "q11": {
+      "q": "What infrastructure is necessary to enable the community?",
+      "a1": "We’ve established a number of teams to support the various efforts associated with developing Rocky Linux:",
+      "a2": "You can read more about this structure when it’s soon published. In order to enable collaboration across and within those teams, we needed to deploy our own chat infrastructure, forums, and website. Additionally, we’re also creating our build infrastructure, which will facilitate the development of the core operating system.",
+      "list": {
+        "community": "Community",
+        "core-inf": "Core Infrastructure",
+        "design": "Design",
+        "documentation": "Documentation",
+        "installer": "Installer",
+        "leadership": "Leadership",
+        "pkg-autob": "Package Auto-Builders",
+        "packaging": "Packaging",
+        "security": "Security",
+        "sigs": "Special Interest Groups (SIGs)",
+        "web": "Web"
+      }
+    },
+    "q12": {
+      "q": "Why does it take so much time to stand up a community and build infrastructure?",
+      "a": "It’s not terribly difficult to deploy a website, forums, or a build infrastructure in a reliable fashion. Our chat program for instance, which uses Mattermost, is distributed on a number of application servers behind a load balancer and was ready in just a couple of weeks. But it does require careful thought and planning to do it in a scalable and secure manner when you need to ensure vendor and platform agnosticity and long-term community involvement."
+    },
+    "q13": {
+      "q": "So what’s the short answer to all of this? What are some things you’re thinking about as you put Rocky Linux together?",
+      "a": "How do we carefully shepherd community trust? How do we ensure that anyone who wants to participate can not only do so immediately, but forever in the future as well? How do we engage and enable the community members who might not be as technical but want to contribute anyway? Solving for all of these challenges will take time, and we would love your help in doing so."
+    },
+    "q14": {
+      "q": "What if I have feedback or my question wasn’t answered here?",
+      "a": "Please email us: <a href=\"mailto:hello@rockylinux.org\">hello@rockylinux.org</a> and we’ll get back to you as soon as we can."
+    }
   }
 }

--- a/src/i18n/locales/zh-hk/translation.json
+++ b/src/i18n/locales/zh-hk/translation.json
@@ -1,73 +1,241 @@
 {
   "language": "zh-hk",
-  "copyright": {
-    "line1": "© 2021 Rocky Linux 項目. 版權所有.",
-    "line2": "CentOS是Red Hat, Inc.的註冊商標，Rocky Linux 項目不屬於Red Hat, Inc.,也不需要獲得其認可"
-  },
-  "errors": {
-    "404": {
-      "explanation": "找不到您請求的資源，請稍後再試。",
-      "title": "找不到頁面。"
+
+  "global": {
+
+    "copyright": {
+      "line1": "© 2021 Rocky Linux 項目. 版權所有.",
+      "line2": "CentOS是Red Hat, Inc.的註冊商標，Rocky Linux 項目不屬於Red Hat, Inc.,也不需要獲得其認可"
+    },
+
+    "links": {
+      "close-menu": "關閉菜單",
+      "wiki": "Wiki",
+      "get-in-touch": "保持聯繫",
+      "get-involved": "參與其中",
+      "go-home": "去到主頁",
+      "join-the-discussion": "參與討論",
+      "posts": "News",
+      "show-your-interest": "Show Your Interest",
+      "sponsors": "Sponsors",
+      "partners": "Partners",
+      "status": "Service Status",
+      "donate": "Donate",
+      "store": "Store",
+      "press": "Press",
+      "download": "Download",
+      "com_charter": "Community Charter",
+      "org_structure": "Organization Structure",
+      "privacy": "Privacy Policy",
+      "see-more": "See More",
+      "see-all": "See All",
+      "documentation": "文檔",
+      "bug-report": "Report a bug"
+    },
+    "socials": {
+      "forums": "Forums",
+      "github": "Github",
+      "reddit": "Reddit",
+      "mattermost": "Mattermost",
+      "twitter": "Twitter"
     }
   },
-  "faq": {
-    "a": {
-      "come-in": "Rocky Linux的目標是像CentOS以前那樣做為下游版本，在上游供應商添加發行版本之後（而不是之前）進行發行。",
-      "downstream-partner-direction": "CentOS項目最近宣布了CentOS戰略轉變，CentOS以前是作為上游供應商的下游版本存在的（它在上游供應商之後收到補丁和更新），而現在它將轉移到上游版本（其中包含上游供應商的之前測試補丁和更新）。另外，對CentOS Linux 8的支持已從2029年5月31日縮短到2021年12月31日。"
+
+  "homepage": {
+    "landing": {
+      "p1": {
+        "heading": "Rocky Linux",
+        "content": "以社區驅動為導向，為您帶來企業級可生產的Linux。"
+      },
+      "p2": {
+        "heading": "Rocky Linux 項目是什麼?",
+        "content": "Rocky Linux是一個社區的企業操作系統，由於下游合作夥伴已經改變了方向，因此它的設計是為與美國頂級企業Linux發行版實現100％ Bug級兼容。社區正在大力發展，Rocky Linux由CentOS項目的創始人Gregory Kurtzer領導，沒有發布的ETA，要求貢獻者使用此站點上提供的通信方式進行聯繫。"
+      }
     },
-    "q": {
-      "come-in": "那麽 Rocky Linux 的優勢在哪呢？",
-      "downstream-partner-direction": "您的意思是\"其下游合作夥伴已改變方向\"？"
-    },
-    "title": "經常被問到的問題"
+    "faq": {
+      "title": "經常被問到的問題",
+      "a": {
+        "come-in": "Rocky Linux的目標是像CentOS以前那樣做為下游版本，在上游供應商添加發行版本之後（而不是之前）進行發行。",
+        "downstream-partner-direction": "CentOS項目最近宣布了CentOS戰略轉變，CentOS以前是作為上游供應商的下游版本存在的（它在上游供應商之後收到補丁和更新），而現在它將轉移到上游版本（其中包含上游供應商的之前測試補丁和更新）。另外，對CentOS Linux 8的支持已從2029年5月31日縮短到2021年12月31日。"
+      },
+      "q": {
+        "come-in": "那麽 Rocky Linux 的優勢在哪呢？",
+        "downstream-partner-direction": "您的意思是\"其下游合作夥伴已改變方向\"？"
+      }
+    }
   },
-  "landing": {
+
+  "download": {
     "p1": {
-      "content": "以社區驅動為導向，為您帶來企業級可生產的Linux。",
-      "heading": "Rocky Linux"
+      "heading": "Downloads",
+      "content": "Download the official release of Rocky Linux from one of our trusted mirrors."
+    },
+    "warning": "The release you can download here is a <i>Release Candidate</i> and should not be used in production. Please check our <a class=\"underline font-medium\" href=\"/faq/\">FAQ</a> for more information.",
+    "table": {
+      "architecture": "Architecture",
+      "iso": "ISOS",
+      "isos": {
+        "minimal": "Minimal",
+        "dvd": "DVD",
+        "boot": "Boot",
+        "checksum": "Checksum"
+      },
+      "packages": "Packages"
     },
     "p2": {
-      "content": "Rocky Linux是一個社區的企業操作系統，由於下游合作夥伴已經改變了方向，因此它的設計是為與美國頂級企業Linux發行版實現100％ Bug級兼容。社區正在大力發展，Rocky Linux由CentOS項目的創始人Gregory Kurtzer領導，沒有發布的ETA，要求貢獻者使用此站點上提供的通信方式進行聯繫。",
-      "heading": "Rocky Linux 項目是什麼?"
+      "content": "As you download and use Rocky Linux, the Rocky Enterprise Software Foundation invites you to <a class=\"text-green-600 dark:text-green-500 font-medium\" href=\"https://chat.rockylinux.org/\">be a part of the community as a contributor</a>. There are many ways to contribute to the project, from documentation, QA, and testing to coding changes for SIGs, providing mirroring or hosting, and helping other users."
     }
   },
+
   "lang": {
     "footer": {
-      "choose-language": "選擇一種語言...",
-      "literal": "Language:"
+      "choose-language": "選擇一種語言..."
     }
   },
-  "links": {
-    "close-menu": "關閉菜單",
-    "documentation": "文檔",
-    "get-in-touch": "保持聯繫",
-    "get-involved": "參與其中",
-    "go-home": "去到主頁",
-    "join-the-discussion": "參與討論",
-    "posts": "News",
-    "show-your-interest": "Show Your Interest",
-    "sponsors": "Sponsors",
-    "donate": "Donate",
-    "store": "Store",
-    "press": "Press"
+
+  "errors": {
+    "404": {
+      "title": "找不到頁面。",
+      "explanation": "找不到您請求的資源，請稍後再試。"
+    }
   },
-  "socials": {
-    "forums": "Forums",
-    "github": "Github",
-    "reddit": "Reddit",
-    "mattermost": "Mattermost",
-    "twitter": "Twitter"
-  },
+
   "news": {
     "title": "News",
     "description": "Stay up-to-date on the latest from The Rocky Linux Project."
   },
+
   "press": {
     "title": "Press",
     "description": "See the latest about Rocky in the press."
   },
+
   "sponsors": {
     "title": "Sponsors",
-    "description": "We would like to thank our sponsors for their support thus far on the project."
+    "description": "We would like to thank our sponsors for their support thus far on the project.",
+    "tag": {
+      "fsponsor": "Founding Sponsor",
+      "psponsor": "Principal Sponsor"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "45drives": {
+        "name": "45Drives",
+        "description": "45Drives offers enterprise storage solutions built on powerful & robust open-source software that allows customers to benefit from the cost savings & flexibility of off-the-shelf hardware. Check them out for a fully supported data storage solution at the best cost per terabyte!"
+      },
+      "opendrives": {
+        "name": "OpenDrives",
+        "description": "OpenDrives is a global provider of enterprise-grade, hyper-scalable, network-attached-storage (NAS) solutions. We deliver the highest performing solutions for our customers - to match individual performance needs - for the most robust, complex and mission-critical projects and workflows, on-premises and into the cloud."
+      },
+      "montavista": {
+        "name": "MontaVista",
+        "description": "MontaVista Software is the leader in embedded commercial Linux, supporting MontaVista CGX, Yocto Project®, CentOS and Rocky Linux. MontaVista offers Open Source Software expertise, commercial-quality Linux distros, cost-effective maintenance and support for 10+ year life-cycles."
+      },
+      "aws": {
+        "name": "Amazon Web Services",
+        "description": "The RESF utilizes AWS to run much of the underlying infrastructure critical to the development and deployment of the services supporting Rocky Linux. From Koji builders for x86_64 and aarch64 running in EC2 to SRPM blob storage in S3, AWS is foundational to much of what we do."
+      }
+    }
+  },
+
+  "partners": {
+    "title": "Partners",
+    "description": "Partners of the RESF represent ongoing relationships of strategic importance to the Rocky Linux project. Through dedication of engineering expertise, infrastructure resources, or other means, their support is critical to our continued success and long term stability.",
+    "tag": {
+      "fpartner": "Founding Partner",
+      "ppartner": "Principal Partner"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "navercloud": {
+        "name": "NAVER Cloud",
+        "description": "NAVER Cloud Platform is a South Korean cloud service that started in 2017 under NAVER Cloud, a subsidiary of NAVER. It provides over 170 individual services in 2021 and holds various security certifications including CSA STAR GOLD, GDPR, and more. It also currently provides cloud services in 10 locations around the world."
+      },
+      "mattermost": {
+        "name": "Mattermost",
+        "description": "Mattermost is an open source messaging solution made for organizations with the highest security requirements. As big believers in the power of open source, Mattermost is thrilled to partner with RESF to help bring an enterprise-grade distribution of Linux to the tech community."
+      }
+    }
+  },
+
+  "faq": {
+    "heading": "Frequently Asked Questions",
+    "q1": {
+      "q": "Where can I download the release candidate?",
+      "a": "https://rockylinux.org/download"
+    },
+    "q2": {
+      "q": "What is a release candidate?",
+      "a": "A release candidate is a beta version of a product that has the potential to be stable.The intent of a release candidate is for the community to test and validate expected functionality of Rocky Linux and report any bugs if present."
+    },
+    "q3": {
+      "q": "Can I use the release candidate in production?",
+      "a": "Under no circumstance should you use a release candidate in a production environment. A release candidate is provided for testing and validation purposes only."
+    },
+    "q4": {
+      "q": "How can I help mirror the release candidate and future Rocky Linux releases?",
+      "a": "Please email <a href=\"mailto:mirrors@rockylinux.org\">mirrors@rockylinux.org</a> to express your interest."
+    },
+    "q5": {
+      "q": "I encountered a bug while testing the release candidate, what can I do?",
+      "a": "First, create an account using <a href=\"https://accounts.rockylinux.org/\"> Rocky Linux Account Services </a> , then head over to our <a href=\"https://bugs.rockylinux.org/\">Bugzilla server</a> to report any bugs."
+    },
+    "q6": {
+      "q": "How can I get involved with the Testing team?",
+      "a": "Please join the <a href=\"https://chat.rockylinux.org/rocky-linux/channels/testing\"> ~Testing </a> channel on our Mattermost server to get started. There’s also a testing topic on the forums for more durable conversation."
+    },
+    "q7": {
+      "q": "Where can I find the latest news about Rocky Linux?",
+      "a": "Stay tuned to our website, Twitter, LinkedIn, forums, and other platforms listed in our link directory for the latest announcements."
+    },
+    "q8": {
+      "q": "If Rocky Linux is just a respin of RHEL, what took so long for a release candidate?",
+      "a1": "If our only goal for Rocky Linux was to debrand and repackage RHEL, we would have been done much sooner. However, what we had to do differently is figure out how we could keep Rocky Linux in the hands of the community. Carefully devising this strategy ensures that Rocky Linux will never meet the same fate of CentOS.",
+      "a2": "The goal was not just to create a community managed RPM based distribution of Linux, but to ensure that it will remain freely available and always in the control of the community, much like Linux itself has. To do that required more than a build infrastructure; it required that we put in place the foundational structures that enable the community, ensuring that Rocky Linux is forever inclusive, free, and open. The infrastructure is built from the ground up by many collaborators and sponsoring organizations around composability and security compliance, providing the substrate for not only the base operating system but also an entire community of diverse interests to take part in the project."
+    },
+    "q9": {
+      "q": "If you’re not just repackaging RHEL, then what exactly are you doing?",
+      "a": "Our goal is to maintain Rocky Linux as a community-oriented distribution <i>by</i> the community, <i>for</i> the community. To do this, we are establishing the necessary organizational structures to ensure that Rocky Linux remains in the hands of the community. We want to make sure that it’s not possible for what happened to CentOS to happen to Rocky Linux."
+    },
+    "q10": {
+      "q": "How will you ensure that Rocky Linux truly remains a community enterprise operating system?",
+      "a": "First, we’ve taken steps to legally protect the Rocky Linux name. This means registering its trademarks and various associated properties to protect them from being controlled by another entity. We’ve achieved this by establishing them under the Rocky Enterprise Software Foundation (RESF). Next, we’re drafting a community charter that will define the organizational structure, objectives, values, and mission behind the legal entity that represents Rocky Linux. Critical in this charter is the establishment of principles that enable and protect the community: transparency, community involvement, open development, and independence. <strong> Rocky Linux will never be controlled, purchased, or otherwise influenced by a single entity or organization. </strong> Finally, we’re architecting and deploying the necessary infrastructure to further enable the community to contribute to Rocky Linux."
+    },
+    "q11": {
+      "q": "What infrastructure is necessary to enable the community?",
+      "a1": "We’ve established a number of teams to support the various efforts associated with developing Rocky Linux:",
+      "a2": "You can read more about this structure when it’s soon published. In order to enable collaboration across and within those teams, we needed to deploy our own chat infrastructure, forums, and website. Additionally, we’re also creating our build infrastructure, which will facilitate the development of the core operating system.",
+      "list": {
+        "community": "Community",
+        "core-inf": "Core Infrastructure",
+        "design": "Design",
+        "documentation": "Documentation",
+        "installer": "Installer",
+        "leadership": "Leadership",
+        "pkg-autob": "Package Auto-Builders",
+        "packaging": "Packaging",
+        "security": "Security",
+        "sigs": "Special Interest Groups (SIGs)",
+        "web": "Web"
+      }
+    },
+    "q12": {
+      "q": "Why does it take so much time to stand up a community and build infrastructure?",
+      "a": "It’s not terribly difficult to deploy a website, forums, or a build infrastructure in a reliable fashion. Our chat program for instance, which uses Mattermost, is distributed on a number of application servers behind a load balancer and was ready in just a couple of weeks. But it does require careful thought and planning to do it in a scalable and secure manner when you need to ensure vendor and platform agnosticity and long-term community involvement."
+    },
+    "q13": {
+      "q": "So what’s the short answer to all of this? What are some things you’re thinking about as you put Rocky Linux together?",
+      "a": "How do we carefully shepherd community trust? How do we ensure that anyone who wants to participate can not only do so immediately, but forever in the future as well? How do we engage and enable the community members who might not be as technical but want to contribute anyway? Solving for all of these challenges will take time, and we would love your help in doing so."
+    },
+    "q14": {
+      "q": "What if I have feedback or my question wasn’t answered here?",
+      "a": "Please email us: <a href=\"mailto:hello@rockylinux.org\">hello@rockylinux.org</a> and we’ll get back to you as soon as we can."
+    }
   }
 }

--- a/src/i18n/locales/zh-tw/translation.json
+++ b/src/i18n/locales/zh-tw/translation.json
@@ -1,73 +1,241 @@
 {
   "language": "zh-tw",
-  "copyright": {
-    "line1": "© 2021 Rocky Linux 專案．版權所有.",
-    "line2": "CentOS 是 Red Hat, Inc. 的註冊商標，Rocky Linux 專案與 Red Hat, Inc. 無關，也不需要獲得其授權"
-  },
-  "errors": {
-    "404": {
-      "explanation": "目前無法開啟這個網頁，請稍後再試。",
-      "title": "找不到這個網頁。"
+
+  "global": {
+
+    "copyright": {
+      "line1": "© 2021 Rocky Linux 專案．版權所有.",
+      "line2": "CentOS 是 Red Hat, Inc. 的註冊商標，Rocky Linux 專案與 Red Hat, Inc. 無關，也不需要獲得其授權"
+    },
+
+    "links": {
+      "close-menu": "關閉選單",
+      "wiki": "Wiki",
+      "get-in-touch": "聯絡我們",
+      "get-involved": "一展長才",
+      "go-home": "回到首頁",
+      "join-the-discussion": "加入討論",
+      "posts": "News",
+      "show-your-interest": "Show Your Interest",
+      "sponsors": "Sponsors",
+      "partners": "Partners",
+      "status": "Service Status",
+      "donate": "Donate",
+      "store": "Store",
+      "press": "Press",
+      "download": "Download",
+      "com_charter": "Community Charter",
+      "org_structure": "Organization Structure",
+      "privacy": "Privacy Policy",
+      "see-more": "See More",
+      "see-all": "See All",
+      "documentation": "參考文件",
+      "bug-report": "Report a bug"
+    },
+    "socials": {
+      "forums": "Forums",
+      "github": "Github",
+      "reddit": "Reddit",
+      "mattermost": "Mattermost",
+      "twitter": "Twitter"
     }
   },
-  "faq": {
-    "a": {
-      "come-in": "Rocky Linux 的目標是延續 CentOS 先前的模式釋出發行版，而不是像 CentOS Stream 一樣成為 RHEL 的前測版本。",
-      "downstream-partner-direction": "CentOS 專案最近宣佈了發行策略上的改變，原本 CentOS 是基於 RHEL 的社群發行版（從 RHEL 接收修補程式和更新），但改成 CentOS Stream 之後反而成為了 RHEL 的前測版本（為 RHEL 測試修補程式和更新）。除此之外，CentOS 8 的生命週期也從 2029 年 5 月 31 日被縮短到 2021 年 12 月 31 日。"
+
+  "homepage": {
+    "landing": {
+      "p1": {
+        "heading": "Rocky Linux",
+        "content": "以社群力量來推動並打造企業級的 Linux 作業系統。"
+      },
+      "p2": {
+        "heading": "為什麼要創建 Rocky Linux 專案？",
+        "content": "Rocky Linux 延續了 Community Enterprise Operating System 精神，是一個基於社群所開發的企業級作業系統，專案當初的考量是希望能與 RHEL 發行版 100％ 完全相容。目前社群處於草創初期，希望有更多對本專案有興趣的成員能夠來參與。Rocky Linux 專案是由 CentOS 的創始人 Gregory Kurtzer 所提出，但目前還沒有 release 的時程，如果您有興趣參與，請使用網頁中提供的方式與相關窗口聯繫。"
+      }
     },
-    "q": {
-      "come-in": "Rocky Linux 為何而生？",
-      "downstream-partner-direction": "「CentOS 發展方向的改變」是什麼意思？"
-    },
-    "title": "常見問題"
+    "faq": {
+      "title": "常見問題",
+      "a": {
+        "come-in": "Rocky Linux 的目標是延續 CentOS 先前的模式釋出發行版，而不是像 CentOS Stream 一樣成為 RHEL 的前測版本。",
+        "downstream-partner-direction": "CentOS 專案最近宣佈了發行策略上的改變，原本 CentOS 是基於 RHEL 的社群發行版（從 RHEL 接收修補程式和更新），但改成 CentOS Stream 之後反而成為了 RHEL 的前測版本（為 RHEL 測試修補程式和更新）。除此之外，CentOS 8 的生命週期也從 2029 年 5 月 31 日被縮短到 2021 年 12 月 31 日。"
+      },
+      "q": {
+        "come-in": "Rocky Linux 為何而生？",
+        "downstream-partner-direction": "「CentOS 發展方向的改變」是什麼意思？"
+      }
+    }
   },
-  "landing": {
+
+  "download": {
     "p1": {
-      "content": "以社群力量來推動並打造企業級的 Linux 作業系統。",
-      "heading": "Rocky Linux"
+      "heading": "Downloads",
+      "content": "Download the official release of Rocky Linux from one of our trusted mirrors."
+    },
+    "warning": "The release you can download here is a <i>Release Candidate</i> and should not be used in production. Please check our <a class=\"underline font-medium\" href=\"/faq/\">FAQ</a> for more information.",
+    "table": {
+      "architecture": "Architecture",
+      "iso": "ISOS",
+      "isos": {
+        "minimal": "Minimal",
+        "dvd": "DVD",
+        "boot": "Boot",
+        "checksum": "Checksum"
+      },
+      "packages": "Packages"
     },
     "p2": {
-      "content": "Rocky Linux 延續了 Community Enterprise Operating System 精神，是一個基於社群所開發的企業級作業系統，專案當初的考量是希望能與 RHEL 發行版 100％ 完全相容。目前社群處於草創初期，希望有更多對本專案有興趣的成員能夠來參與。Rocky Linux 專案是由 CentOS 的創始人 Gregory Kurtzer 所提出，但目前還沒有 release 的時程，如果您有興趣參與，請使用網頁中提供的方式與相關窗口聯繫。",
-      "heading": "為什麼要創建 Rocky Linux 專案？"
+      "content": "As you download and use Rocky Linux, the Rocky Enterprise Software Foundation invites you to <a class=\"text-green-600 dark:text-green-500 font-medium\" href=\"https://chat.rockylinux.org/\">be a part of the community as a contributor</a>. There are many ways to contribute to the project, from documentation, QA, and testing to coding changes for SIGs, providing mirroring or hosting, and helping other users."
     }
   },
+
   "lang": {
     "footer": {
-      "choose-language": "選擇其他語言...",
-      "literal": "Language:"
+      "choose-language": "選擇其他語言..."
     }
   },
-  "links": {
-    "close-menu": "關閉選單",
-    "documentation": "參考文件",
-    "get-in-touch": "聯絡我們",
-    "get-involved": "一展長才",
-    "go-home": "回到首頁",
-    "join-the-discussion": "加入討論",
-    "posts": "News",
-    "show-your-interest": "Show Your Interest",
-    "sponsors": "Sponsors",
-    "donate": "Donate",
-    "store": "Store",
-    "press": "Press"
+
+  "errors": {
+    "404": {
+      "title": "找不到這個網頁。",
+      "explanation": "目前無法開啟這個網頁，請稍後再試。"
+    }
   },
-  "socials": {
-    "forums": "Forums",
-    "github": "Github",
-    "reddit": "Reddit",
-    "mattermost": "Mattermost",
-    "twitter": "Twitter"
-  },
+
   "news": {
     "title": "News",
     "description": "Stay up-to-date on the latest from The Rocky Linux Project."
   },
+
   "press": {
     "title": "Press",
     "description": "See the latest about Rocky in the press."
   },
+
   "sponsors": {
     "title": "Sponsors",
-    "description": "We would like to thank our sponsors for their support thus far on the project."
+    "description": "We would like to thank our sponsors for their support thus far on the project.",
+    "tag": {
+      "fsponsor": "Founding Sponsor",
+      "psponsor": "Principal Sponsor"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "45drives": {
+        "name": "45Drives",
+        "description": "45Drives offers enterprise storage solutions built on powerful & robust open-source software that allows customers to benefit from the cost savings & flexibility of off-the-shelf hardware. Check them out for a fully supported data storage solution at the best cost per terabyte!"
+      },
+      "opendrives": {
+        "name": "OpenDrives",
+        "description": "OpenDrives is a global provider of enterprise-grade, hyper-scalable, network-attached-storage (NAS) solutions. We deliver the highest performing solutions for our customers - to match individual performance needs - for the most robust, complex and mission-critical projects and workflows, on-premises and into the cloud."
+      },
+      "montavista": {
+        "name": "MontaVista",
+        "description": "MontaVista Software is the leader in embedded commercial Linux, supporting MontaVista CGX, Yocto Project®, CentOS and Rocky Linux. MontaVista offers Open Source Software expertise, commercial-quality Linux distros, cost-effective maintenance and support for 10+ year life-cycles."
+      },
+      "aws": {
+        "name": "Amazon Web Services",
+        "description": "The RESF utilizes AWS to run much of the underlying infrastructure critical to the development and deployment of the services supporting Rocky Linux. From Koji builders for x86_64 and aarch64 running in EC2 to SRPM blob storage in S3, AWS is foundational to much of what we do."
+      }
+    }
+  },
+
+  "partners": {
+    "title": "Partners",
+    "description": "Partners of the RESF represent ongoing relationships of strategic importance to the Rocky Linux project. Through dedication of engineering expertise, infrastructure resources, or other means, their support is critical to our continued success and long term stability.",
+    "tag": {
+      "fpartner": "Founding Partner",
+      "ppartner": "Principal Partner"
+    },
+    "list": {
+      "ciq": {
+        "name": "Ctrl IQ",
+        "description": "Unified, secured, platform agnostic computing starting with the provisioning, management, and support of the base OS (Rocky Linux) and going through the deployment stack of containers with cloud native, multi-prem, multi-cloud meta-orchestration of performance critical workflows and data."
+      },
+      "navercloud": {
+        "name": "NAVER Cloud",
+        "description": "NAVER Cloud Platform is a South Korean cloud service that started in 2017 under NAVER Cloud, a subsidiary of NAVER. It provides over 170 individual services in 2021 and holds various security certifications including CSA STAR GOLD, GDPR, and more. It also currently provides cloud services in 10 locations around the world."
+      },
+      "mattermost": {
+        "name": "Mattermost",
+        "description": "Mattermost is an open source messaging solution made for organizations with the highest security requirements. As big believers in the power of open source, Mattermost is thrilled to partner with RESF to help bring an enterprise-grade distribution of Linux to the tech community."
+      }
+    }
+  },
+
+  "faq": {
+    "heading": "Frequently Asked Questions",
+    "q1": {
+      "q": "Where can I download the release candidate?",
+      "a": "https://rockylinux.org/download"
+    },
+    "q2": {
+      "q": "What is a release candidate?",
+      "a": "A release candidate is a beta version of a product that has the potential to be stable.The intent of a release candidate is for the community to test and validate expected functionality of Rocky Linux and report any bugs if present."
+    },
+    "q3": {
+      "q": "Can I use the release candidate in production?",
+      "a": "Under no circumstance should you use a release candidate in a production environment. A release candidate is provided for testing and validation purposes only."
+    },
+    "q4": {
+      "q": "How can I help mirror the release candidate and future Rocky Linux releases?",
+      "a": "Please email <a href=\"mailto:mirrors@rockylinux.org\">mirrors@rockylinux.org</a> to express your interest."
+    },
+    "q5": {
+      "q": "I encountered a bug while testing the release candidate, what can I do?",
+      "a": "First, create an account using <a href=\"https://accounts.rockylinux.org/\"> Rocky Linux Account Services </a> , then head over to our <a href=\"https://bugs.rockylinux.org/\">Bugzilla server</a> to report any bugs."
+    },
+    "q6": {
+      "q": "How can I get involved with the Testing team?",
+      "a": "Please join the <a href=\"https://chat.rockylinux.org/rocky-linux/channels/testing\"> ~Testing </a> channel on our Mattermost server to get started. There’s also a testing topic on the forums for more durable conversation."
+    },
+    "q7": {
+      "q": "Where can I find the latest news about Rocky Linux?",
+      "a": "Stay tuned to our website, Twitter, LinkedIn, forums, and other platforms listed in our link directory for the latest announcements."
+    },
+    "q8": {
+      "q": "If Rocky Linux is just a respin of RHEL, what took so long for a release candidate?",
+      "a1": "If our only goal for Rocky Linux was to debrand and repackage RHEL, we would have been done much sooner. However, what we had to do differently is figure out how we could keep Rocky Linux in the hands of the community. Carefully devising this strategy ensures that Rocky Linux will never meet the same fate of CentOS.",
+      "a2": "The goal was not just to create a community managed RPM based distribution of Linux, but to ensure that it will remain freely available and always in the control of the community, much like Linux itself has. To do that required more than a build infrastructure; it required that we put in place the foundational structures that enable the community, ensuring that Rocky Linux is forever inclusive, free, and open. The infrastructure is built from the ground up by many collaborators and sponsoring organizations around composability and security compliance, providing the substrate for not only the base operating system but also an entire community of diverse interests to take part in the project."
+    },
+    "q9": {
+      "q": "If you’re not just repackaging RHEL, then what exactly are you doing?",
+      "a": "Our goal is to maintain Rocky Linux as a community-oriented distribution <i>by</i> the community, <i>for</i> the community. To do this, we are establishing the necessary organizational structures to ensure that Rocky Linux remains in the hands of the community. We want to make sure that it’s not possible for what happened to CentOS to happen to Rocky Linux."
+    },
+    "q10": {
+      "q": "How will you ensure that Rocky Linux truly remains a community enterprise operating system?",
+      "a": "First, we’ve taken steps to legally protect the Rocky Linux name. This means registering its trademarks and various associated properties to protect them from being controlled by another entity. We’ve achieved this by establishing them under the Rocky Enterprise Software Foundation (RESF). Next, we’re drafting a community charter that will define the organizational structure, objectives, values, and mission behind the legal entity that represents Rocky Linux. Critical in this charter is the establishment of principles that enable and protect the community: transparency, community involvement, open development, and independence. <strong> Rocky Linux will never be controlled, purchased, or otherwise influenced by a single entity or organization. </strong> Finally, we’re architecting and deploying the necessary infrastructure to further enable the community to contribute to Rocky Linux."
+    },
+    "q11": {
+      "q": "What infrastructure is necessary to enable the community?",
+      "a1": "We’ve established a number of teams to support the various efforts associated with developing Rocky Linux:",
+      "a2": "You can read more about this structure when it’s soon published. In order to enable collaboration across and within those teams, we needed to deploy our own chat infrastructure, forums, and website. Additionally, we’re also creating our build infrastructure, which will facilitate the development of the core operating system.",
+      "list": {
+        "community": "Community",
+        "core-inf": "Core Infrastructure",
+        "design": "Design",
+        "documentation": "Documentation",
+        "installer": "Installer",
+        "leadership": "Leadership",
+        "pkg-autob": "Package Auto-Builders",
+        "packaging": "Packaging",
+        "security": "Security",
+        "sigs": "Special Interest Groups (SIGs)",
+        "web": "Web"
+      }
+    },
+    "q12": {
+      "q": "Why does it take so much time to stand up a community and build infrastructure?",
+      "a": "It’s not terribly difficult to deploy a website, forums, or a build infrastructure in a reliable fashion. Our chat program for instance, which uses Mattermost, is distributed on a number of application servers behind a load balancer and was ready in just a couple of weeks. But it does require careful thought and planning to do it in a scalable and secure manner when you need to ensure vendor and platform agnosticity and long-term community involvement."
+    },
+    "q13": {
+      "q": "So what’s the short answer to all of this? What are some things you’re thinking about as you put Rocky Linux together?",
+      "a": "How do we carefully shepherd community trust? How do we ensure that anyone who wants to participate can not only do so immediately, but forever in the future as well? How do we engage and enable the community members who might not be as technical but want to contribute anyway? Solving for all of these challenges will take time, and we would love your help in doing so."
+    },
+    "q14": {
+      "q": "What if I have feedback or my question wasn’t answered here?",
+      "a": "Please email us: <a href=\"mailto:hello@rockylinux.org\">hello@rockylinux.org</a> and we’ll get back to you as soon as we can."
+    }
   }
 }

--- a/src/pages/download.jsx
+++ b/src/pages/download.jsx
@@ -4,7 +4,7 @@ import Footer from '../components/footer';
 import Header from '../components/header';
 import Layout from '../components/layout';
 import SEO from '../components/seo';
-import {Translate} from "../i18n/utils/translate";
+import { Translate } from '../i18n/utils/translate';
 import dompurify from 'dompurify';
 
 const DownloadPage = ({ pageContext }) => {
@@ -46,7 +46,13 @@ const DownloadPage = ({ pageContext }) => {
           </div>
           <div className="max-w-screen-md px-8 mx-auto mt-4 flex flex-col">
             <div className="w-full px-3 py-2 rounded-lg shadow bg-red-600 text-white mb-4 text-center">
-              <span dangerouslySetInnerHTML={{__html: sanitizer(translate('download.warning'), {ALLOWED_TAGS: ['i', 'a']})}}></span>
+              <span
+                dangerouslySetInnerHTML={{
+                  __html: sanitizer(translate('download.warning'), {
+                    ALLOWED_TAGS: ['i', 'a'],
+                  }),
+                }}
+              ></span>
             </div>
           </div>
           <div className="shadow overflow-x-auto overflow-y-hidden rounded-md shadow max-w-screen-md mx-auto">
@@ -180,8 +186,14 @@ const DownloadPage = ({ pageContext }) => {
                 {translate('global.links.bug-report')}
               </a>
             </div>
-            <p dangerouslySetInnerHTML={{__html: sanitizer(translate('download.p2.content'), {ALLOWED_TAGS: ['a']})}} className="text-gray-700 dark:text-gray-300">
-            </p>
+            <p
+              dangerouslySetInnerHTML={{
+                __html: sanitizer(translate('download.p2.content'), {
+                  ALLOWED_TAGS: ['a'],
+                }),
+              }}
+              className="text-gray-700 dark:text-gray-300"
+            ></p>
           </div>
         </div>
       </main>

--- a/src/pages/download.jsx
+++ b/src/pages/download.jsx
@@ -4,8 +4,13 @@ import Footer from '../components/footer';
 import Header from '../components/header';
 import Layout from '../components/layout';
 import SEO from '../components/seo';
+import {Translate} from "../i18n/utils/translate";
+import dompurify from 'dompurify';
 
 const DownloadPage = ({ pageContext }) => {
+  const translate = Translate();
+  const sanitizer = dompurify.sanitize;
+
   return (
     <Layout>
       <SEO />
@@ -32,24 +37,16 @@ const DownloadPage = ({ pageContext }) => {
               </div>
             </div>
             <h2 className="mb-4 font-sans text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-50 sm:text-4xl sm:leading-none">
-              Downloads
+              {translate('download.p1.heading')}
             </h2>
             <p className="text-base text-gray-700 dark:text-gray-300 md:text-lg sm:px-4">
-              Download the official release of Rocky Linux from one of our
-              trusted mirrors.
+              {translate('download.p1.content')}
             </p>
             <hr className="mx-auto" />
           </div>
           <div className="max-w-screen-md px-8 mx-auto mt-4 flex flex-col">
             <div className="w-full px-3 py-2 rounded-lg shadow bg-red-600 text-white mb-4 text-center">
-              <span>
-                The release you can download here is a <i>Release Candidate</i>{' '}
-                and should not be used in production. Please check our{' '}
-                <Link className="underline font-medium" to="/faq/">
-                  FAQ
-                </Link>{' '}
-                for more information.
-              </span>
+              <span dangerouslySetInnerHTML={{__html: sanitizer(translate('download.warning'), {ALLOWED_TAGS: ['i', 'a']})}}></span>
             </div>
           </div>
           <div className="shadow overflow-x-auto overflow-y-hidden rounded-md shadow max-w-screen-md mx-auto">
@@ -60,19 +57,19 @@ const DownloadPage = ({ pageContext }) => {
                     scope="col"
                     className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider"
                   >
-                    Architecture
+                    {translate('download.table.architecture')}
                   </th>
                   <th
                     scope="col"
                     className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider"
                   >
-                    ISOs
+                    {translate('download.table.iso')}
                   </th>
                   <th
                     scope="col"
                     className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider"
                   >
-                    Packages
+                    {translate('download.table.packages')}
                   </th>
                 </tr>
               </thead>
@@ -85,7 +82,7 @@ const DownloadPage = ({ pageContext }) => {
                       onClick="_paq.push(['trackEvent', 'Download', 'Download', 'x86_64 Minimal', 1]);"
                       href="https://download.rockylinux.org/pub/rocky/8.3/isos/x86_64/Rocky-8.3-x86_64-minimal.iso"
                     >
-                      Minimal
+                      {translate('download.table.isos.minimal')}
                     </a>{' '}
                     |&nbsp;
                     <a
@@ -93,7 +90,7 @@ const DownloadPage = ({ pageContext }) => {
                       onClick="_paq.push(['trackEvent', 'Download', 'Download', 'x86_64 DVD', 1]);"
                       href="https://download.rockylinux.org/pub/rocky/8.3/isos/x86_64/Rocky-8.3-x86_64-dvd1.iso"
                     >
-                      DVD
+                      {translate('download.table.isos.dvd')}
                     </a>{' '}
                     |&nbsp;
                     <a
@@ -101,14 +98,14 @@ const DownloadPage = ({ pageContext }) => {
                       onClick="_paq.push(['trackEvent', 'Download', 'Download', 'x86_64 Boot', 1]);"
                       href="https://download.rockylinux.org/pub/rocky/8.3/isos/x86_64/Rocky-8.3-x86_64-boot.iso"
                     >
-                      Boot
+                      {translate('download.table.isos.boot')}
                     </a>{' '}
                     |&nbsp;
                     <a
                       className="font-medium text-green-600 dark:text-green-500"
                       href="https://download.rockylinux.org/pub/rocky/8.3/isos/x86_64/CHECKSUM"
                     >
-                      Checksum
+                      {translate('download.table.isos.checksum')}
                     </a>
                   </td>
                   <td className="px-6 py-3 whitespace-nowrap">
@@ -130,7 +127,7 @@ const DownloadPage = ({ pageContext }) => {
                       onClick="_paq.push(['trackEvent', 'Download', 'Download', 'aarch64 Minimal', 1]);"
                       href="https://download.rockylinux.org/pub/rocky/8.3/isos/aarch64/Rocky-8.3-aarch64-minimal.iso"
                     >
-                      Minimal
+                      {translate('download.table.isos.minimal')}
                     </a>{' '}
                     |&nbsp;
                     <a
@@ -138,7 +135,7 @@ const DownloadPage = ({ pageContext }) => {
                       onClick="_paq.push(['trackEvent', 'Download', 'Download', 'aarch64 DVD', 1]);"
                       href="https://download.rockylinux.org/pub/rocky/8.3/isos/aarch64/Rocky-8.3-aarch64-dvd1.iso"
                     >
-                      DVD
+                      {translate('download.table.isos.dvd')}
                     </a>{' '}
                     |&nbsp;
                     <a
@@ -146,14 +143,14 @@ const DownloadPage = ({ pageContext }) => {
                       onClick="_paq.push(['trackEvent', 'Download', 'Download', 'aarch64 Boot', 1]);"
                       href="https://download.rockylinux.org/pub/rocky/8.3/isos/aarch64/Rocky-8.3-aarch64-boot.iso"
                     >
-                      Boot
+                      {translate('download.table.isos.boot')}
                     </a>{' '}
                     |&nbsp;
                     <a
                       className="font-medium text-green-600 dark:text-green-500"
                       href="https://download.rockylinux.org/pub/rocky/8.3/isos/aarch64/CHECKSUM"
                     >
-                      Checksum
+                      {translate('download.table.isos.checksum')}
                     </a>
                   </td>
                   <td className="px-6 py-3 whitespace-nowrap">
@@ -174,27 +171,16 @@ const DownloadPage = ({ pageContext }) => {
                 className="text-green-600 dark:text-green-500 font-medium"
                 href="https://docs.rockylinux.org/site-index"
               >
-                Documentation
+                {translate('global.links.documentation')}
               </a>
               <a
                 className="text-green-600 dark:text-green-500 font-medium"
                 href="https://bugs.rockylinux.org"
               >
-                Report a bug
+                {translate('global.links.bug-report')}
               </a>
             </div>
-            <p className="text-gray-700 dark:text-gray-300">
-              As you download and use Rocky Linux, the Rocky Enterprise Software
-              Foundation invites you to{' '}
-              <a
-                className="text-green-600 dark:text-green-500 font-medium"
-                href="https://chat.rockylinux.org"
-              >
-                be a part of the community as a contributor
-              </a>
-              . There are many ways to contribute to the project, from
-              documentation, QA, and testing to coding changes for SIGs,
-              providing mirroring or hosting, and helping other users.
+            <p dangerouslySetInnerHTML={{__html: sanitizer(translate('download.p2.content'), {ALLOWED_TAGS: ['a']})}} className="text-gray-700 dark:text-gray-300">
             </p>
           </div>
         </div>

--- a/src/pages/faq.jsx
+++ b/src/pages/faq.jsx
@@ -4,138 +4,130 @@ import SEO from '../components/seo';
 import Header from '../components/header';
 import Footer from '../components/footer';
 import dompurify from 'dompurify';
-import {Translate} from "../i18n/utils/translate";
+import { Translate } from '../i18n/utils/translate';
 
 const Faq = ({ data, pageContext: { locale: language } }) => {
   const translate = Translate();
   const sanitizer = dompurify.sanitize;
 
   return (
-      <Layout>
-        <SEO title="Frequently Asked Questions" />
-        <Header pageContext="{locale: language}" />
-        <main className="bg-gray-50 dark:bg-gray-900 text-gray-800 dark:text-white z-0">
-          <div className="px-4 py-16 mx-auto sm:max-w-xl md:max-w-full lg:max-w-screen-xl md:px-24 lg:px-8 lg:py-20">
-            <div className="max-w-xl sm:mx-auto lg:max-w-2xl">
-              <div className="max-w-xl mb-10 md:mx-auto sm:text-center lg:max-w-2xl md:mb-14">
-                <h2 className="max-w-lg mb-10 font-sans text-3xl font-bold leading-none tracking-tight text-gray-900 dark:text-gray-50 sm:text-4xl md:mx-auto text-center">
-                  {translate('faq.heading')}
-                </h2>
-                <hr className="mx-auto" />
-              </div>
-            </div>
-            <div className="max-w-screen-xl sm:mx-auto">
-              <div className="prose mx-auto dark-mode:prose-dark dark:text-gray-300">
-                <h5 className="font-bold">
-                  {translate('faq.q1.q')}
-                </h5>
-                <p>
-                  <a href="https://rockylinux.org/download">
-                    https://rockylinux.org/download
-                  </a>
-                </p>
-                <hr />
-                <h5 className="font-bold">{translate('faq.q2.q')}</h5>
-                <p>
-                  {translate('faq.q2.a')}
-                </p>
-                <hr />
-                <h5 className="font-bold">
-                  {translate('faq.q3.q')}
-                </h5>
-                <p>
-                  {translate('faq.q3.a')}
-                </p>
-                <hr />
-                <h5 className="font-bold">
-                  {translate('faq.q4.q')}
-                </h5>
-                <p dangerouslySetInnerHTML={{__html: sanitizer(translate('faq.q4.a'), {ALLOWED_TAGS: ['a']})}}></p>
-                <hr />
-                <h5 className="font-bold">
-                  {translate('faq.q5.q')}
-                </h5>
-                <p dangerouslySetInnerHTML={{__html: sanitizer(translate('faq.q5.a'), {ALLOWED_TAGS: ['a']})}}></p>
-                <hr />
-                <h5 className="font-bold">
-                  {translate('faq.q6.q')}
-                </h5>
-                <p dangerouslySetInnerHTML={{__html: sanitizer(translate('faq.q6.a'), {ALLOWED_TAGS: ['a']})}}></p>
-                <hr />
-                <h5 className="font-bold">
-                  {translate('faq.q7.q')}
-                </h5>
-                <p>
-                  {translate('faq.q7.a')}
-                </p>
-                <hr />
-                <h5 className="font-bold">
-                  {translate('faq.q8.q')}
-                </h5>
-                <p>
-                  {translate('faq.q8.a1')}
-                </p>
-                <p>
-                  {translate('faq.q8.a2')}
-                </p>
-                <hr />
-                <h5 className="font-bold">
-                  {translate('faq.q9.q')}
-                </h5>
-                <p dangerouslySetInnerHTML={{__html: sanitizer(translate('faq.q9.a'), {ALLOWED_TAGS: ['i']})}}></p>
-                <hr />
-                <h5 className="font-bold">
-                  {translate('faq.q10.q')}
-                </h5>
-                <p dangerouslySetInnerHTML={{__html: sanitizer(translate('faq.q10.a'), {ALLOWED_TAGS: ['strong']})}}></p>
-                <hr />
-                <h5 className="font-bold">
-                  {translate('faq.q11.q')}
-                </h5>
-                <p>
-                  {translate('faq.q11.a1')}
-                </p>
-                <ul>
-                  <li>{translate('faq.q11.list.community')}</li>
-                  <li>{translate('faq.q11.list.core-inf')}</li>
-                  <li>{translate('faq.q11.list.design')}</li>
-                  <li>{translate('faq.q11.list.documentation')}</li>
-                  <li>{translate('faq.q11.list.installer')}</li>
-                  <li>{translate('faq.q11.list.leadership')}</li>
-                  <li>{translate('faq.q11.list.pkg-autob')}</li>
-                  <li>{translate('faq.q11.list.packaging')}</li>
-                  <li>{translate('faq.q11.list.security')}</li>
-                  <li>{translate('faq.q11.list.sigs')}</li>
-                  <li>{translate('faq.q11.list.web')}</li>
-                </ul>
-                <p>
-                  {translate('faq.q11.a2')}
-                </p>
-                <hr />
-                <h5 className="font-bold">
-                  {translate('faq.q12.q')}
-                </h5>
-                <p>
-                  {translate('faq.q12.a')}
-                </p>
-                <hr />
-                <h5 className="font-bold">
-                  {translate('faq.q13.q')}
-                </h5>
-                <p>
-                  {translate('faq.q13.a')}
-                </p>
-                <hr />
-                <h5 className="font-bold">
-                  {translate('faq.q14.q')}
-                </h5>
-                <p dangerouslySetInnerHTML={{__html: sanitizer(translate('faq.q14.a'), {ALLOWED_TAGS: ['a']})}}></p>
-              </div>
+    <Layout>
+      <SEO title="Frequently Asked Questions" />
+      <Header pageContext="{locale: language}" />
+      <main className="bg-gray-50 dark:bg-gray-900 text-gray-800 dark:text-white z-0">
+        <div className="px-4 py-16 mx-auto sm:max-w-xl md:max-w-full lg:max-w-screen-xl md:px-24 lg:px-8 lg:py-20">
+          <div className="max-w-xl sm:mx-auto lg:max-w-2xl">
+            <div className="max-w-xl mb-10 md:mx-auto sm:text-center lg:max-w-2xl md:mb-14">
+              <h2 className="max-w-lg mb-10 font-sans text-3xl font-bold leading-none tracking-tight text-gray-900 dark:text-gray-50 sm:text-4xl md:mx-auto text-center">
+                {translate('faq.heading')}
+              </h2>
+              <hr className="mx-auto" />
             </div>
           </div>
-        </main>
-        <Footer pageContext="{locale: language}" />
-      </Layout>
+          <div className="max-w-screen-xl sm:mx-auto">
+            <div className="prose mx-auto dark-mode:prose-dark dark:text-gray-300">
+              <h5 className="font-bold">{translate('faq.q1.q')}</h5>
+              <p>
+                <a href="https://rockylinux.org/download">
+                  https://rockylinux.org/download
+                </a>
+              </p>
+              <hr />
+              <h5 className="font-bold">{translate('faq.q2.q')}</h5>
+              <p>{translate('faq.q2.a')}</p>
+              <hr />
+              <h5 className="font-bold">{translate('faq.q3.q')}</h5>
+              <p>{translate('faq.q3.a')}</p>
+              <hr />
+              <h5 className="font-bold">{translate('faq.q4.q')}</h5>
+              <p
+                dangerouslySetInnerHTML={{
+                  __html: sanitizer(translate('faq.q4.a'), {
+                    ALLOWED_TAGS: ['a'],
+                  }),
+                }}
+              ></p>
+              <hr />
+              <h5 className="font-bold">{translate('faq.q5.q')}</h5>
+              <p
+                dangerouslySetInnerHTML={{
+                  __html: sanitizer(translate('faq.q5.a'), {
+                    ALLOWED_TAGS: ['a'],
+                  }),
+                }}
+              ></p>
+              <hr />
+              <h5 className="font-bold">{translate('faq.q6.q')}</h5>
+              <p
+                dangerouslySetInnerHTML={{
+                  __html: sanitizer(translate('faq.q6.a'), {
+                    ALLOWED_TAGS: ['a'],
+                  }),
+                }}
+              ></p>
+              <hr />
+              <h5 className="font-bold">{translate('faq.q7.q')}</h5>
+              <p>{translate('faq.q7.a')}</p>
+              <hr />
+              <h5 className="font-bold">{translate('faq.q8.q')}</h5>
+              <p>{translate('faq.q8.a1')}</p>
+              <p>{translate('faq.q8.a2')}</p>
+              <hr />
+              <h5 className="font-bold">{translate('faq.q9.q')}</h5>
+              <p
+                dangerouslySetInnerHTML={{
+                  __html: sanitizer(translate('faq.q9.a'), {
+                    ALLOWED_TAGS: ['i'],
+                  }),
+                }}
+              ></p>
+              <hr />
+              <h5 className="font-bold">{translate('faq.q10.q')}</h5>
+              <p
+                dangerouslySetInnerHTML={{
+                  __html: sanitizer(translate('faq.q10.a'), {
+                    ALLOWED_TAGS: ['strong'],
+                  }),
+                }}
+              ></p>
+              <hr />
+              <h5 className="font-bold">{translate('faq.q11.q')}</h5>
+              <p>{translate('faq.q11.a1')}</p>
+              <ul>
+                <li>{translate('faq.q11.list.community')}</li>
+                <li>{translate('faq.q11.list.core-inf')}</li>
+                <li>{translate('faq.q11.list.design')}</li>
+                <li>{translate('faq.q11.list.documentation')}</li>
+                <li>{translate('faq.q11.list.installer')}</li>
+                <li>{translate('faq.q11.list.leadership')}</li>
+                <li>{translate('faq.q11.list.pkg-autob')}</li>
+                <li>{translate('faq.q11.list.packaging')}</li>
+                <li>{translate('faq.q11.list.security')}</li>
+                <li>{translate('faq.q11.list.sigs')}</li>
+                <li>{translate('faq.q11.list.web')}</li>
+              </ul>
+              <p>{translate('faq.q11.a2')}</p>
+              <hr />
+              <h5 className="font-bold">{translate('faq.q12.q')}</h5>
+              <p>{translate('faq.q12.a')}</p>
+              <hr />
+              <h5 className="font-bold">{translate('faq.q13.q')}</h5>
+              <p>{translate('faq.q13.a')}</p>
+              <hr />
+              <h5 className="font-bold">{translate('faq.q14.q')}</h5>
+              <p
+                dangerouslySetInnerHTML={{
+                  __html: sanitizer(translate('faq.q14.a'), {
+                    ALLOWED_TAGS: ['a'],
+                  }),
+                }}
+              ></p>
+            </div>
+          </div>
+        </div>
+      </main>
+      <Footer pageContext="{locale: language}" />
+    </Layout>
   );
 };
 

--- a/src/pages/faq.jsx
+++ b/src/pages/faq.jsx
@@ -3,234 +3,139 @@ import Layout from '../components/layout';
 import SEO from '../components/seo';
 import Header from '../components/header';
 import Footer from '../components/footer';
+import dompurify from 'dompurify';
+import {Translate} from "../i18n/utils/translate";
 
 const Faq = ({ data, pageContext: { locale: language } }) => {
+  const translate = Translate();
+  const sanitizer = dompurify.sanitize;
+
   return (
-    <Layout>
-      <SEO title="Frequently Asked Questions" />
-      <Header pageContext="{locale: language}" />
-      <main className="bg-gray-50 dark:bg-gray-900 text-gray-800 dark:text-white z-0">
-        <div className="px-4 py-16 mx-auto sm:max-w-xl md:max-w-full lg:max-w-screen-xl md:px-24 lg:px-8 lg:py-20">
-          <div className="max-w-xl sm:mx-auto lg:max-w-2xl">
-            <div className="max-w-xl mb-10 md:mx-auto sm:text-center lg:max-w-2xl md:mb-14">
-              <h2 className="max-w-lg mb-10 font-sans text-3xl font-bold leading-none tracking-tight text-gray-900 dark:text-gray-50 sm:text-4xl md:mx-auto text-center">
-                Frequently Asked Questions
-              </h2>
-              <hr className="mx-auto" />
+      <Layout>
+        <SEO title="Frequently Asked Questions" />
+        <Header pageContext="{locale: language}" />
+        <main className="bg-gray-50 dark:bg-gray-900 text-gray-800 dark:text-white z-0">
+          <div className="px-4 py-16 mx-auto sm:max-w-xl md:max-w-full lg:max-w-screen-xl md:px-24 lg:px-8 lg:py-20">
+            <div className="max-w-xl sm:mx-auto lg:max-w-2xl">
+              <div className="max-w-xl mb-10 md:mx-auto sm:text-center lg:max-w-2xl md:mb-14">
+                <h2 className="max-w-lg mb-10 font-sans text-3xl font-bold leading-none tracking-tight text-gray-900 dark:text-gray-50 sm:text-4xl md:mx-auto text-center">
+                  {translate('faq.heading')}
+                </h2>
+                <hr className="mx-auto" />
+              </div>
+            </div>
+            <div className="max-w-screen-xl sm:mx-auto">
+              <div className="prose mx-auto dark-mode:prose-dark dark:text-gray-300">
+                <h5 className="font-bold">
+                  {translate('faq.q1.q')}
+                </h5>
+                <p>
+                  <a href="https://rockylinux.org/download">
+                    https://rockylinux.org/download
+                  </a>
+                </p>
+                <hr />
+                <h5 className="font-bold">{translate('faq.q2.q')}</h5>
+                <p>
+                  {translate('faq.q2.a')}
+                </p>
+                <hr />
+                <h5 className="font-bold">
+                  {translate('faq.q3.q')}
+                </h5>
+                <p>
+                  {translate('faq.q3.a')}
+                </p>
+                <hr />
+                <h5 className="font-bold">
+                  {translate('faq.q4.q')}
+                </h5>
+                <p dangerouslySetInnerHTML={{__html: sanitizer(translate('faq.q4.a'), {ALLOWED_TAGS: ['a']})}}></p>
+                <hr />
+                <h5 className="font-bold">
+                  {translate('faq.q5.q')}
+                </h5>
+                <p dangerouslySetInnerHTML={{__html: sanitizer(translate('faq.q5.a'), {ALLOWED_TAGS: ['a']})}}></p>
+                <hr />
+                <h5 className="font-bold">
+                  {translate('faq.q6.q')}
+                </h5>
+                <p dangerouslySetInnerHTML={{__html: sanitizer(translate('faq.q6.a'), {ALLOWED_TAGS: ['a']})}}></p>
+                <hr />
+                <h5 className="font-bold">
+                  {translate('faq.q7.q')}
+                </h5>
+                <p>
+                  {translate('faq.q7.a')}
+                </p>
+                <hr />
+                <h5 className="font-bold">
+                  {translate('faq.q8.q')}
+                </h5>
+                <p>
+                  {translate('faq.q8.a1')}
+                </p>
+                <p>
+                  {translate('faq.q8.a2')}
+                </p>
+                <hr />
+                <h5 className="font-bold">
+                  {translate('faq.q9.q')}
+                </h5>
+                <p dangerouslySetInnerHTML={{__html: sanitizer(translate('faq.q9.a'), {ALLOWED_TAGS: ['i']})}}></p>
+                <hr />
+                <h5 className="font-bold">
+                  {translate('faq.q10.q')}
+                </h5>
+                <p dangerouslySetInnerHTML={{__html: sanitizer(translate('faq.q10.a'), {ALLOWED_TAGS: ['strong']})}}></p>
+                <hr />
+                <h5 className="font-bold">
+                  {translate('faq.q11.q')}
+                </h5>
+                <p>
+                  {translate('faq.q11.a1')}
+                </p>
+                <ul>
+                  <li>{translate('faq.q11.list.community')}</li>
+                  <li>{translate('faq.q11.list.core-inf')}</li>
+                  <li>{translate('faq.q11.list.design')}</li>
+                  <li>{translate('faq.q11.list.documentation')}</li>
+                  <li>{translate('faq.q11.list.installer')}</li>
+                  <li>{translate('faq.q11.list.leadership')}</li>
+                  <li>{translate('faq.q11.list.pkg-autob')}</li>
+                  <li>{translate('faq.q11.list.packaging')}</li>
+                  <li>{translate('faq.q11.list.security')}</li>
+                  <li>{translate('faq.q11.list.sigs')}</li>
+                  <li>{translate('faq.q11.list.web')}</li>
+                </ul>
+                <p>
+                  {translate('faq.q11.a2')}
+                </p>
+                <hr />
+                <h5 className="font-bold">
+                  {translate('faq.q12.q')}
+                </h5>
+                <p>
+                  {translate('faq.q12.a')}
+                </p>
+                <hr />
+                <h5 className="font-bold">
+                  {translate('faq.q13.q')}
+                </h5>
+                <p>
+                  {translate('faq.q13.a')}
+                </p>
+                <hr />
+                <h5 className="font-bold">
+                  {translate('faq.q14.q')}
+                </h5>
+                <p dangerouslySetInnerHTML={{__html: sanitizer(translate('faq.q14.a'), {ALLOWED_TAGS: ['a']})}}></p>
+              </div>
             </div>
           </div>
-          <div className="max-w-screen-xl sm:mx-auto">
-            <div className="prose mx-auto dark-mode:prose-dark dark:text-gray-300">
-              <h5 className="font-bold">
-                Where can I download the release candidate?
-              </h5>
-              <p>
-                <a href="https://rockylinux.org/download">
-                  https://rockylinux.org/download
-                </a>
-              </p>
-              <hr />
-              <h5 className="font-bold">What is a release candidate?</h5>
-              <p>
-                A release candidate is a beta version of a product that has the
-                potential to be stable.The intent of a release candidate is for
-                the community to test and validate expected functionality of
-                Rocky Linux and report any bugs if present.
-              </p>
-              <hr />
-              <h5 className="font-bold">
-                Can I use the release candidate in production?
-              </h5>
-              <p>
-                Under no circumstance should you use a release candidate in a
-                production environment. A release candidate is provided for
-                testing and validation purposes only.
-              </p>
-              <hr />
-              <h5 className="font-bold">
-                How can I help mirror the release candidate and future Rocky
-                Linux releases?
-              </h5>
-              <p>
-                Please email{' '}
-                <a href="mailto:mirrors@rockylinux.org">
-                  mirrors@rockylinux.org
-                </a>{' '}
-                to express your interest.
-              </p>
-              <hr />
-              <h5 className="font-bold">
-                I encountered a bug while testing the release candidate, what
-                can I do?
-              </h5>
-              <p>
-                First, create an account using{' '}
-                <a href="https://accounts.rockylinux.org/">
-                  Rocky Linux Account Services
-                </a>
-                , then head over to our{' '}
-                <a href="https://bugs.rockylinux.org/">Bugzilla server</a> to
-                report any bugs.
-              </p>
-              <hr />
-              <h5 className="font-bold">
-                How can I get involved with the Testing team?
-              </h5>
-              <p>
-                Please join the{' '}
-                <a href="https://chat.rockylinux.org/rocky-linux/channels/testing">
-                  ~Testing
-                </a>{' '}
-                channel on our Mattermost server to get started. There’s also a
-                testing topic on the forums for more durable conversation.
-              </p>
-              <hr />
-              <h5 className="font-bold">
-                Where can I find the latest news about Rocky Linux?
-              </h5>
-              <p>
-                Stay tuned to our website, Twitter, LinkedIn, forums, and other
-                platforms listed in our link directory for the latest
-                announcements.
-              </p>
-              <hr />
-              <h5 className="font-bold">
-                If Rocky Linux is just a respin of RHEL, what took so long for a
-                release candidate?
-              </h5>
-              <p>
-                If our only goal for Rocky Linux was to debrand and repackage
-                RHEL, we would have been done much sooner. However, what we had
-                to do differently is figure out how we could keep Rocky Linux in
-                the hands of the community. Carefully devising this strategy
-                ensures that Rocky Linux will never meet the same fate of
-                CentOS.
-              </p>
-              <p>
-                The goal was not just to create a community managed RPM based
-                distribution of Linux, but to ensure that it will remain freely
-                available and always in the control of the community, much like
-                Linux itself has. To do that required more than a build
-                infrastructure; it required that we put in place the
-                foundational structures that enable the community, ensuring that
-                Rocky Linux is forever inclusive, free, and open. The
-                infrastructure is built from the ground up by many collaborators
-                and sponsoring organizations around composability and security
-                compliance, providing the substrate for not only the base
-                operating system but also an entire community of diverse
-                interests to take part in the project.
-              </p>
-              <hr />
-              <h5 className="font-bold">
-                If you’re not just repackaging RHEL, then what exactly are you
-                doing?
-              </h5>
-              <p>
-                Our goal is to maintain Rocky Linux as a community-oriented
-                distribution <i>by</i> the community, <i>for</i> the community.
-                To do this, we are establishing the necessary organizational
-                structures to ensure that Rocky Linux remains in the hands of
-                the community. We want to make sure that it’s not possible for
-                what happened to CentOS to happen to Rocky Linux.
-              </p>
-              <hr />
-              <h5 className="font-bold">
-                How will you ensure that Rocky Linux truly remains a community
-                enterprise operating system?
-              </h5>
-              <p>
-                First, we’ve taken steps to legally protect the Rocky Linux
-                name. This means registering its trademarks and various
-                associated properties to protect them from being controlled by
-                another entity. We’ve achieved this by establishing them under
-                the Rocky Enterprise Software Foundation (RESF). Next, we’re
-                drafting a community charter that will define the organizational
-                structure, objectives, values, and mission behind the legal
-                entity that represents Rocky Linux. Critical in this charter is
-                the establishment of principles that enable and protect the
-                community: transparency, community involvement, open
-                development, and independence.{' '}
-                <strong>
-                  Rocky Linux will never be controlled, purchased, or otherwise
-                  influenced by a single entity or organization.
-                </strong>{' '}
-                Finally, we’re architecting and deploying the necessary
-                infrastructure to further enable the community to contribute to
-                Rocky Linux.
-              </p>
-              <hr />
-              <h5 className="font-bold">
-                What infrastructure is necessary to enable the community?
-              </h5>
-              <p>
-                We’ve established a number of teams to support the various
-                efforts associated with developing Rocky Linux:
-              </p>
-              <ul>
-                <li>Community</li>
-                <li>Core Infrastructure</li>
-                <li>Design</li>
-                <li>Documentation</li>
-                <li>Installer</li>
-                <li>Leadership</li>
-                <li>Package Auto-Builders</li>
-                <li>Packaging</li>
-                <li>Security</li>
-                <li>Special Interest Groups (SIGs)</li>
-                <li>Web</li>
-              </ul>
-              <p>
-                You can read more about this structure when it’s soon published.
-                In order to enable collaboration across and within those teams,
-                we needed to deploy our own chat infrastructure, forums, and
-                website. Additionally, we’re also creating our build
-                infrastructure, which will facilitate the development of the
-                core operating system.
-              </p>
-              <hr />
-              <h5 className="font-bold">
-                Why does it take so much time to stand up a community and build
-                infrastructure?
-              </h5>
-              <p>
-                It’s not terribly difficult to deploy a website, forums, or a
-                build infrastructure in a reliable fashion. Our chat program for
-                instance, which uses Mattermost, is distributed on a number of
-                application servers behind a load balancer and was ready in just
-                a couple of weeks. But it does require careful thought and
-                planning to do it in a scalable and secure manner when you need
-                to ensure vendor and platform agnosticity and long-term
-                community involvement.
-              </p>
-              <hr />
-              <h5 className="font-bold">
-                So what’s the short answer to all of this? What are some things
-                you’re thinking about as you put Rocky Linux together?
-              </h5>
-              <p>
-                How do we carefully shepherd community trust? How do we ensure
-                that anyone who wants to participate can not only do so
-                immediately, but forever in the future as well? How do we engage
-                and enable the community members who might not be as technical
-                but want to contribute anyway? Solving for all of these
-                challenges will take time, and we would love your help in doing
-                so.
-              </p>
-              <hr />
-              <h5 className="font-bold">
-                What if I have feedback or my question wasn’t answered here?
-              </h5>
-              <p>
-                Please email us:{' '}
-                <a href="mailto:hello@rockylinux.org">hello@rockylinux.org</a>{' '}
-                and we’ll get back to you as soon as we can.
-              </p>
-            </div>
-          </div>
-        </div>
-      </main>
-      <Footer pageContext="{locale: language}" />
-    </Layout>
+        </main>
+        <Footer pageContext="{locale: language}" />
+      </Layout>
   );
 };
 

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -27,10 +27,10 @@ const Index = ({ pageContext: { locale: language } }) => {
           <div className="flex flex-col mb-16 text-center sm:mb-0">
             <div className="max-w-xl mb-10 md:mx-auto sm:text-center lg:max-w-2xl md:mb-12">
               <h2 className="max-w-lg mb-6 font-sans text-3xl font-bold leading-none tracking-tight text-gray-900 dark:text-white sm:text-6xl md:mx-auto">
-                {translate('landing.p1.heading')}
+                {translate('homepage.landing.p1.heading')}
               </h2>
               <p className="text-base text-gray-500 dark:text-gray-300 md:text-lg">
-                {translate('landing.p1.content')}
+                {translate('homepage.landing.p1.content')}
               </p>
             </div>
             <div>
@@ -52,7 +52,7 @@ const Index = ({ pageContext: { locale: language } }) => {
                     d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
                   />
                 </svg>
-                {translate('links.download')}
+                {translate('global.links.download')}
               </LocalizedLink>
               <a
                 href="https://chat.rockylinux.org/"
@@ -66,7 +66,7 @@ const Index = ({ pageContext: { locale: language } }) => {
                 >
                   <path d="M16.109 0C9.396-.047 3.12 4.167.849 10.869c-2.833 8.371 1.656 17.448 10.02 20.281 8.371 2.833 17.448-1.656 20.281-10.02 2.303-6.803-.229-14.068-5.749-18.079l.172 3.396c2.749 3.041 3.839 7.349 2.468 11.401-2.047 6.041-8.791 9.219-15.068 7.093-6.276-2.125-9.708-8.745-7.661-14.792 1.376-4.057 4.876-6.828 8.928-7.557L16.427.004c-.104-.005-.213-.005-.323-.005zm4.703 1.459a.471.471 0 00-.167.031h-.005a.556.556 0 00-.145.099c-.192.188-.875 1.105-.875 1.105l-1.484 1.837-1.735 2.115-2.98 3.704s-1.364 1.703-1.061 3.801c.301 2.1 1.859 3.12 3.072 3.532 1.208.405 3.068.541 4.584-.943 1.515-1.48 1.463-3.667 1.463-3.667l-.115-4.745-.093-2.735-.063-2.364s.011-1.141-.025-1.412a.698.698 0 00-.047-.14l-.011-.016-.005-.016a.39.39 0 00-.308-.187z" />
                 </svg>
-                {translate('links.join-the-discussion')}
+                {translate('global.links.join-the-discussion')}
               </a>
             </div>
           </div>
@@ -81,12 +81,12 @@ const Index = ({ pageContext: { locale: language } }) => {
             <div className="flex flex-col lg:flex-row">
               <div className="mb-6 lg:mb-0 lg:w-1/2 lg:pr-5">
                 <h2 className="font-sans text-3xl font-bold tracking-tight text-gray-900 dark:text-white sm:text-4xl sm:leading-none">
-                  {translate('landing.p2.heading')}
+                  {translate('homepage.landing.p2.heading')}
                 </h2>
               </div>
               <div className="lg:w-1/2">
                 <p className="text-base text-gray-600 dark:text-gray-300">
-                  {translate('landing.p2.content')}
+                  {translate('homepage.landing.p2.content')}
                 </p>
               </div>
             </div>
@@ -98,14 +98,14 @@ const Index = ({ pageContext: { locale: language } }) => {
           <div className="max-w-xl sm:mx-auto lg:max-w-2xl">
             <div className="max-w-xl mb-10 md:mx-auto sm:text-center lg:max-w-2xl md:mb-12">
               <h2 className="max-w-lg mb-6 font-sans text-3xl font-bold leading-none tracking-tight text-gray-900 dark:text-gray-100 sm:text-4xl md:mx-auto text-center">
-                {translate('faq.title')}
+                {translate('homepage.faq.title')}
               </h2>
               <div className="text-center mt-5">
                 <LocalizedLink
                   to="/faq/"
                   className="inline-flex items-center px-4 py-2 border border-transparent text-base leading-6 font-medium rounded-md shadow-md text-green-500 bg-white dark:bg-gray-800 hover:text-green-400 focus:outline-none focus:border-green-300 focus:shadow-outline-green active:bg-gray-50 active:text-gray-700 transition duration-150 ease-in-out"
                 >
-                  See More
+                  {translate('global.links.see-more')}
                 </LocalizedLink>
               </div>
             </div>
@@ -115,21 +115,21 @@ const Index = ({ pageContext: { locale: language } }) => {
               <dl className="space-y-8 divide-y divide-gray-300 dark:divide-white">
                 <div className="md:grid md:grid-cols-12 md:gap-8">
                   <dt className="text-base font-bold text-gray-900 dark:text-gray-200 md:col-span-5">
-                    {translate('faq.q.downstream-partner-direction')}
+                    {translate('homepage.faq.q.downstream-partner-direction')}
                   </dt>
                   <dd className="mt-2 md:mt-0 md:col-span-7">
                     <p className="text-base text-gray-600 dark:text-gray-300">
-                      {translate('faq.a.downstream-partner-direction')}
+                      {translate('homepage.faq.a.downstream-partner-direction')}
                     </p>
                   </dd>
                 </div>
                 <div className="pt-6 md:grid md:grid-cols-12 md:gap-8">
                   <dt className="text-base font-bold text-gray-900 dark:text-gray-200 md:col-span-5">
-                    {translate('faq.q.come-in')}
+                    {translate('homepage.faq.q.come-in')}
                   </dt>
                   <dd className="mt-2 md:mt-0 md:col-span-7">
                     <p className="text-base text-gray-600 dark:text-gray-300">
-                      {translate('faq.a.come-in')}
+                      {translate('homepage.faq.a.come-in')}
                     </p>
                   </dd>
                 </div>
@@ -145,7 +145,7 @@ const Index = ({ pageContext: { locale: language } }) => {
         <div className="px-4 py-16 mx-auto sm:max-w-xl md:max-w-full lg:max-w-screen-md md:px-4 lg:px-4 lg:py-4">
           <div className="max-w-xl mb-6 md:mx-auto text-center lg:max-w-2xl md:mb-6">
             <h2 className="max-w-lg font-sans text-3xl font-bold leading-none tracking-tight text-gray-900 dark:text-gray-50 sm:text-4xl md:mx-auto">
-              {translate('links.sponsors')}
+              {translate('global.links.sponsors')}
             </h2>
           </div>
           <div className="bg-gray-100 dark:bg-gray-800 rounded-lg shadow-md mb-6">
@@ -219,7 +219,7 @@ const Index = ({ pageContext: { locale: language } }) => {
                   />
                 </svg>
               </span>
-              See All
+              {translate('global.links.see-all')}
             </LocalizedLink>
           </div>
         </div>

--- a/src/pages/partners.jsx
+++ b/src/pages/partners.jsx
@@ -9,8 +9,13 @@ import MattermostLogo from '../images/mattermost.png';
 import NaverLogo from '../images/naver.png';
 import FossHostLogo from '../images/fosshost.png';
 import FastlyLogo from '../images/fastly.png';
+import {Translate} from "../i18n/utils/translate";
+import dompurify from "dompurify";
 
 const Sponsors = ({ data, pageContext: { locale: language } }) => {
+  const translate = Translate();
+  const sanitizer = dompurify.sanitize;
+
   return (
     <Layout>
       <SEO title="Partners" />
@@ -37,14 +42,10 @@ const Sponsors = ({ data, pageContext: { locale: language } }) => {
                 </div>
               </div>
               <h2 className="mb-4 font-sans text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-50 sm:text-4xl sm:leading-none">
-                Partners
+                {translate('partners.title')}
               </h2>
               <p className="text-base text-gray-700 dark:text-gray-300 md:text-lg sm:px-4">
-                Partners of the RESF represent ongoing relationships of
-                strategic importance to the Rocky Linux project. Through
-                dedication of engineering expertise, infrastructure resources,
-                or other means, their support is critical to our continued
-                success and long term stability.
+                {translate('partners.description')}
               </p>
               <hr className="mx-auto" />
             </div>
@@ -64,18 +65,14 @@ const Sponsors = ({ data, pageContext: { locale: language } }) => {
                 <h3 className="text-lg font-medium text-gray-50">
                   <a href="https://ctrliq.com" className="focus:outline-none">
                     <span className="absolute inset-0" aria-hidden="true" />
-                    Ctrl IQ
+                    {translate('partners.list.ciq.name')}
                     <span className="ml-2 bg-green-200 text-green-600 py-1 px-2 text-xs rounded-full self-center">
-                      Founding Partner
+                      {translate('partners.tag.fpartner')}
                     </span>
                   </a>
                 </h3>
                 <p className="mt-2 text-sm text-gray-200">
-                  Unified, secured, platform agnostic computing starting with
-                  the provisioning, management, and support of the base OS
-                  (Rocky Linux) and going through the deployment stack of
-                  containers with cloud native, multi-prem, multi-cloud
-                  meta-orchestration of performance critical workflows and data.
+                  {translate('partners.list.ciq.description')}
                 </p>
               </div>
             </div>
@@ -93,19 +90,14 @@ const Sponsors = ({ data, pageContext: { locale: language } }) => {
                 <h3 className="text-lg font-medium text-gray-50">
                   <a href="https://ncloud.com/" className="focus:outline-none">
                     <span className="absolute inset-0" aria-hidden="true" />
-                    NAVER Cloud
+                    {translate('partners.list.navercloud.name')}
                     <span className="ml-2 bg-green-700 text-green-100 py-1 px-2 text-xs rounded-full self-center">
-                      Principal Partner
+                      {translate('partners.tag.ppartner')}
                     </span>
                   </a>
                 </h3>
                 <p className="mt-2 text-sm text-gray-200">
-                  NAVER Cloud Platform is a South Korean cloud service that
-                  started in 2017 under NAVER Cloud, a subsidiary of NAVER. It
-                  provides over 170 individual services in 2021 and holds
-                  various security certifications including CSA STAR GOLD, GDPR,
-                  and more. It also currently provides cloud services in 10
-                  locations around the world.
+                  {translate('partners.list.navercloud.description')}
                 </p>
               </div>
             </div>
@@ -126,18 +118,14 @@ const Sponsors = ({ data, pageContext: { locale: language } }) => {
                     className="focus:outline-none"
                   >
                     <span className="absolute inset-0" aria-hidden="true" />
-                    Mattermost
+                    {translate('partners.list.mattermost.name')}
                     <span className="ml-2 bg-green-700 text-green-100 py-1 px-2 text-xs rounded-full self-center">
-                      Principal Partner
+                      {translate('partners.tag.ppartner')}
                     </span>
                   </a>
                 </h3>
                 <p className="mt-2 text-sm text-gray-200">
-                  Mattermost is an open source messaging solution made for
-                  organizations with the highest security requirements. As big
-                  believers in the power of open source, Mattermost is thrilled
-                  to partner with RESF to help bring an enterprise-grade
-                  distribution of Linux to the tech community.
+                  {translate('partners.list.mattermost.description')}
                 </p>
               </div>
             </div>

--- a/src/pages/partners.jsx
+++ b/src/pages/partners.jsx
@@ -9,8 +9,8 @@ import MattermostLogo from '../images/mattermost.png';
 import NaverLogo from '../images/naver.png';
 import FossHostLogo from '../images/fosshost.png';
 import FastlyLogo from '../images/fastly.png';
-import {Translate} from "../i18n/utils/translate";
-import dompurify from "dompurify";
+import { Translate } from '../i18n/utils/translate';
+import dompurify from 'dompurify';
 
 const Sponsors = ({ data, pageContext: { locale: language } }) => {
   const translate = Translate();

--- a/src/pages/sponsors.jsx
+++ b/src/pages/sponsors.jsx
@@ -9,8 +9,8 @@ import CIQLogo from '../images/ciq-alt.png';
 import AwsLogo from '../images/aws-alt.png';
 import FortyFiveDrivesLogo from '../images/45drives.jpg';
 import MontaVistaLogo from '../images/montavista.png';
-import {Translate} from "../i18n/utils/translate";
-import dompurify from "dompurify";
+import { Translate } from '../i18n/utils/translate';
+import dompurify from 'dompurify';
 
 const Sponsors = ({ data, pageContext: { locale: language } }) => {
   const translate = Translate();

--- a/src/pages/sponsors.jsx
+++ b/src/pages/sponsors.jsx
@@ -9,8 +9,13 @@ import CIQLogo from '../images/ciq-alt.png';
 import AwsLogo from '../images/aws-alt.png';
 import FortyFiveDrivesLogo from '../images/45drives.jpg';
 import MontaVistaLogo from '../images/montavista.png';
+import {Translate} from "../i18n/utils/translate";
+import dompurify from "dompurify";
 
 const Sponsors = ({ data, pageContext: { locale: language } }) => {
+  const translate = Translate();
+  const sanitizer = dompurify.sanitize;
+
   return (
     <Layout>
       <SEO title="Sponsors" />
@@ -37,11 +42,10 @@ const Sponsors = ({ data, pageContext: { locale: language } }) => {
                 </div>
               </div>
               <h2 className="mb-4 font-sans text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-50 sm:text-4xl sm:leading-none">
-                Sponsors
+                {translate('sponsors.title')}
               </h2>
               <p className="text-base text-gray-700 dark:text-gray-300 md:text-lg sm:px-4">
-                We would like to thank our sponsors for their support thus far
-                on the project.
+                {translate('sponsors.description')}
               </p>
               <hr className="mx-auto" />
             </div>
@@ -61,18 +65,14 @@ const Sponsors = ({ data, pageContext: { locale: language } }) => {
                 <h3 className="text-lg font-medium text-gray-50">
                   <a href="https://ctrliq.com" className="focus:outline-none">
                     <span className="absolute inset-0" aria-hidden="true" />
-                    Ctrl IQ
+                    {translate('sponsors.list.ciq.name')}
                     <span className="ml-2 bg-green-200 text-green-600 py-1 px-2 text-xs rounded-full self-center">
-                      Founding Sponsor
+                      {translate('sponsors.tag.fsponsor')}
                     </span>
                   </a>
                 </h3>
                 <p className="mt-2 text-sm text-gray-200">
-                  Unified, secured, platform agnostic computing starting with
-                  the provisioning, management, and support of the base OS
-                  (Rocky Linux) and going through the deployment stack of
-                  containers with cloud native, multi-prem, multi-cloud
-                  meta-orchestration of performance critical workflows and data.
+                  {translate('sponsors.list.ciq.description')}
                 </p>
               </div>
             </div>
@@ -93,18 +93,14 @@ const Sponsors = ({ data, pageContext: { locale: language } }) => {
                     className="focus:outline-none"
                   >
                     <span className="absolute inset-0" aria-hidden="true" />
-                    45Drives
+                    {translate('sponsors.list.45drives.name')}
                     <span className="ml-2 bg-green-700 text-green-100 py-1 px-2 text-xs rounded-full self-center">
-                      Principal Sponsor
+                      {translate('sponsors.tag.psponsor')}
                     </span>
                   </a>
                 </h3>
                 <p className="mt-2 text-sm text-gray-200">
-                  45Drives offers enterprise storage solutions built on powerful
-                  & robust open-source software that allows customers to benefit
-                  from the cost savings & flexibility of off-the-shelf hardware.
-                  Check them out for a fully supported data storage solution at
-                  the best cost per terabyte!
+                  {translate('sponsors.list.45drives.description')}
                 </p>
               </div>
             </div>
@@ -125,19 +121,14 @@ const Sponsors = ({ data, pageContext: { locale: language } }) => {
                     className="focus:outline-none"
                   >
                     <span className="absolute inset-0" aria-hidden="true" />
-                    OpenDrives
+                    {translate('sponsors.list.opendrives.name')}
                     <span className="ml-2 bg-green-700 text-green-100 py-1 px-2 text-xs rounded-full self-center">
-                      Principal Sponsor
+                      {translate('sponsors.tag.psponsor')}
                     </span>
                   </a>
                 </h3>
                 <p className="mt-2 text-sm text-gray-200">
-                  OpenDrives is a global provider of enterprise-grade,
-                  hyper-scalable, network-attached-storage (NAS) solutions. We
-                  deliver the highest performing solutions for our customers -
-                  to match individual performance needs - for the most robust,
-                  complex and mission-critical projects and workflows,
-                  on-premises and into the cloud.
+                  {translate('sponsors.list.opendrives.description')}
                 </p>
               </div>
             </div>
@@ -155,18 +146,14 @@ const Sponsors = ({ data, pageContext: { locale: language } }) => {
                 <h3 className="text-lg font-medium text-gray-50">
                   <a href="https://mvista.com/" className="focus:outline-none">
                     <span className="absolute inset-0" aria-hidden="true" />
-                    MontaVista
+                    {translate('sponsors.list.montavista.name')}
                     <span className="ml-2 bg-green-700 text-green-100 py-1 px-2 text-xs rounded-full self-center">
-                      Principal Sponsor
+                      {translate('sponsors.tag.psponsor')}
                     </span>
                   </a>
                 </h3>
                 <p className="mt-2 text-sm text-gray-200">
-                  MontaVista Software is the leader in embedded commercial
-                  Linux, supporting MontaVista CGX, Yocto Project®, CentOS and
-                  Rocky Linux. MontaVista offers Open Source Software expertise,
-                  commercial-quality Linux distros, cost-effective maintenance
-                  and support for 10+ year life-cycles.
+                  {translate('sponsors.list.montavista.description')}
                 </p>
               </div>
             </div>
@@ -187,18 +174,14 @@ const Sponsors = ({ data, pageContext: { locale: language } }) => {
                     className="focus:outline-none"
                   >
                     <span className="absolute inset-0" aria-hidden="true" />
-                    Amazon Web Services
+                    {translate('sponsors.list.aws.name')}
                     <span className="ml-2 bg-green-700 text-green-100 py-1 px-2 text-xs rounded-full self-center">
-                      Principal Sponsor
+                      {translate('sponsors.tag.psponsor')}
                     </span>
                   </a>
                 </h3>
                 <p className="mt-2 text-sm text-gray-200">
-                  The RESF utilizes AWS to run much of the underlying
-                  infrastructure critical to the development and deployment of
-                  the services supporting Rocky Linux. From Koji builders for
-                  x86_64 and aarch64 running in EC2 to SRPM blob storage in S3,
-                  AWS is foundational to much of what we do.
+                  {translate('sponsors.list.aws.description')}
                 </p>
               </div>
             </div>


### PR DESCRIPTION
Linked to issue #108 

Added the possibility to translate these 3 links:

- `Community Charter` > links.com_charter
- `Organizational Structure` > links.org_structure
- `Privacy Policy` > links.privacy

Added in translation.json:
```
"links": {
    "com_charter": "Community Charter",
    "org_structure": "Organization Structure",
    "privacy": "Privacy Policy"
}
```  

Changes made on src/components/footer/index.jsx to set hardcoded text into variable.
