### PR TITLE
Add missing translation for german

### DIFF
--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -47,8 +47,11 @@
     "show-your-interest": "Show Your Interest",
     "sponsors": "Sponsors",
     "donate": "Donate",
+    "status": "Service Status",
     "store": "Store",
-    "press": "Press"
+    "partners": "Partner",
+    "press": "Press",
+    "download": "Herunterladen"
   },
   "socials": {
     "forums": "Forums",


### PR DESCRIPTION
Closes #113 .
However the problem still persists for different languages.
The fields `download`, `partners` and `status` were missing in the german translation.