### PR TITLE
Add a redirect to the latest available ISOs and images

### DIFF
--- a/src/pages/download.js
+++ b/src/pages/download.js
@@ -305,16 +305,16 @@ const DownloadPage = ({ data, pageContext: { locale: language } }) => {
                       “EAR”) and other U.S. and foreign laws and may not be
                       exported, re-exported or transferred (a) to a prohibited
                       destination country under the EAR or U.S. sanctions
-                      regulations (currently Cuba, Iran, North Korea,
-                      Syria, and the Crimea Region of Ukraine, subject to change
-                      as posted by the United States government); (b) to any
-                      prohibited destination or to any end user who has been
-                      prohibited from participating in U.S. export transactions
-                      by any federal agency of the U.S. government; or (c) for
-                      use in connection with the design, development or
-                      production of nuclear, chemical or biological weapons, or
-                      rocket systems, space launch vehicles, or sounding
-                      rockets, or unmanned air vehicle systems.
+                      regulations (currently Cuba, Iran, North Korea, Syria, and
+                      the Crimea Region of Ukraine, subject to change as posted
+                      by the United States government); (b) to any prohibited
+                      destination or to any end user who has been prohibited
+                      from participating in U.S. export transactions by any
+                      federal agency of the U.S. government; or (c) for use in
+                      connection with the design, development or production of
+                      nuclear, chemical or biological weapons, or rocket
+                      systems, space launch vehicles, or sounding rockets, or
+                      unmanned air vehicle systems.
                     </p>
                   </div>
                 </div>

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "source": "/migrate2rocky.sh",
       "destination": "https://raw.githubusercontent.com/rocky-linux/rocky-tools/main/migrate2rocky/migrate2rocky.sh"
+    },
+    {
+      "source": "/dl/(?<type>)/(?<architecture>(x86_64|arm64|ppc64le|s390x))/?$",
+      "destination": "https://dl.rockylinux.org/pub/rocky/8/isos/:architecture/Rocky-8.5-:architecture-:type.iso"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -5,15 +5,15 @@
       "destination": "https://raw.githubusercontent.com/rocky-linux/rocky-tools/main/migrate2rocky/migrate2rocky.sh"
     },
     {
-      "source": "/dl/(?<type>(dvd1|boot|minimal))/(?<architecture>(x86_64|aarch64|ppc64le|s390x))/?$",
+      "source": "/dl/:type(dvd1|boot|minimal)/:architecture(x86_64|aarch64|ppc64le|s390x)",
       "destination": "https://dl.rockylinux.org/pub/rocky/8/isos/:architecture/Rocky-8.5-:architecture-:type.iso"
     },
     {
-      "source": "/dl/(?<type>(genericcloud|GenericCloud))/x86_64/?$",
+      "source": "/dl/:type(genericcloud|GenericCloud)/x86_64",
       "destination": "https://dl.rockylinux.org/pub/rocky/8/images/Rocky-8-GenericCloud-8.5-20211114.2.x86_64.qcow2"
     },
     {
-      "source": "/dl/(?<type>(genericcloud|GenericCloud))/aarch64/?$",
+      "source": "/dl/:type(genericcloud|GenericCloud)/aarch64",
       "destination": "https://dl.rockylinux.org/pub/rocky/8/images/Rocky-8-GenericCloud-8.5.20211114.1.aarch64.qcow2"
     }
   ]

--- a/vercel.json
+++ b/vercel.json
@@ -5,8 +5,16 @@
       "destination": "https://raw.githubusercontent.com/rocky-linux/rocky-tools/main/migrate2rocky/migrate2rocky.sh"
     },
     {
-      "source": "/dl/(?<type>)/(?<architecture>(x86_64|arm64|ppc64le|s390x))/?$",
+      "source": "/dl/(?<type>(dvd1|boot|minimal))/(?<architecture>(x86_64|aarch64|ppc64le|s390x))/?$",
       "destination": "https://dl.rockylinux.org/pub/rocky/8/isos/:architecture/Rocky-8.5-:architecture-:type.iso"
+    },
+    {
+      "source": "/dl/(?<type>(genericcloud|GenericCloud))/x86_64/?$",
+      "destination": "https://dl.rockylinux.org/pub/rocky/8/images/Rocky-8-GenericCloud-8.5-20211114.2.x86_64.qcow2"
+    },
+    {
+      "source": "/dl/(?<type>(genericcloud|GenericCloud))/aarch64/?$",
+      "destination": "https://dl.rockylinux.org/pub/rocky/8/images/Rocky-8-GenericCloud-8.5.20211114.1.aarch64.qcow2"
     }
   ]
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/680198/161771248-1560a6f0-f519-4ede-9439-770d894ee195.png)

I haven't tested it, but the substitutions should be fine.

makes urls convert like:

```
https://rockylinux.org/dl/dvd1/x86_64/ => https://dl.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-8.5-x86_64-dvd1.iso
```

etc
