### PR TITLE
Fix Traditional Chinese name on language selector

### DIFF
--- a/i18n/config.json
+++ b/i18n/config.json
@@ -19,7 +19,7 @@
     "code": "zh_TW",
     "hrefLang": "zh-tw",
     "name": "Chinese Traditional",
-    "localName": "中國傳統的",
+    "localName": "正體中文",
     "langDir": "ltr",
     "dateFormat": "YYYY-MM-DD"
   },


### PR DESCRIPTION
The language name was absolutely wrong. This PR addresses the problem.
Linked issue: #391 