### PR TITLE
Update Security Advisory page URL

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -29,7 +29,7 @@ const Footer = ({ pageContext: { locale: language } }) => {
       },
       {
         name: `${translate('about.errata')}`,
-        href: 'https://errata.rockylinux.org',
+        href: 'https://errata.build.resf.org',
       },
     ],
     getinvolved: [


### PR DESCRIPTION
I noticed that the page footer still has the old Errata page in it,
this PR changes that to the new one.